### PR TITLE
chore: setup lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,5 @@
+pre-commit:
+  commands:
+    check:
+      glob: "*.{js,ts,jsx,tsx,json}"
+      run: biome check --apply {staged_files}

--- a/package.json
+++ b/package.json
@@ -29,18 +29,14 @@
 	"capabilities": {
 		"untrustedWorkspaces": {
 			"supported": "limited",
-			"restrictedConfigurations": [
-				"biome.lspBin"
-			]
+			"restrictedConfigurations": ["biome.lspBin"]
 		}
 	},
 	"contributes": {
 		"languages": [
 			{
 				"id": "biome_syntax_tree",
-				"extensions": [
-					".rast"
-				]
+				"extensions": [".rast"]
 			}
 		],
 		"grammars": [
@@ -82,32 +78,18 @@
 				"biome_lsp.trace.server": {
 					"type": "string",
 					"scope": "window",
-					"enum": [
-						"off",
-						"messages",
-						"verbose"
-					],
-					"enumDescriptions": [
-						"No traces",
-						"Error only",
-						"Full log"
-					],
+					"enum": ["off", "messages", "verbose"],
+					"enumDescriptions": ["No traces", "Error only", "Full log"],
 					"default": "off",
 					"description": "Traces the communication between VS Code and the language server."
 				},
 				"biome.lspBin": {
-					"type": [
-						"string",
-						"null"
-					],
+					"type": ["string", "null"],
 					"default": null,
 					"markdownDescription": "The biome lsp server executable. If the path is relative, the workspace folder will be used as base path"
 				},
 				"biome.rename": {
-					"type": [
-						"boolean",
-						"null"
-					],
+					"type": ["boolean", "null"],
 					"default": null,
 					"markdownDescription": "Enable/Disable Biome handling renames in the workspace. (Experimental)"
 				},
@@ -119,14 +101,8 @@
 			}
 		}
 	},
-	"categories": [
-		"Formatters",
-		"Linters"
-	],
-	"keywords": [
-		"Formatter",
-		"Linter"
-	],
+	"categories": ["Formatters", "Linters"],
+	"keywords": ["Formatter", "Linter"],
 	"license": "MIT",
 	"scripts": {
 		"compile": "esbuild src/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=node14",
@@ -138,7 +114,8 @@
 		"check": "biome check .",
 		"check:apply": "biome check . --apply-unsafe",
 		"pack:dev": "pnpm run compile && pnpm run package && pnpm run install-extension",
-		"tsc": "tsc"
+		"tsc": "tsc",
+		"prepare": "lefthook install"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.2.2",
@@ -148,6 +125,7 @@
 		"@types/vscode": "^1.80.0",
 		"@vscode/vsce": "^2.20.1",
 		"esbuild": "^0.19.2",
+		"lefthook": "^1.5.2",
 		"typescript": "^5.1.6"
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ devDependencies:
   esbuild:
     specifier: ^0.19.2
     version: 0.19.2
+  lefthook:
+    specifier: ^1.5.2
+    version: 1.5.2
   typescript:
     specifier: ^5.1.6
     version: 5.1.6
@@ -741,6 +744,85 @@ packages:
       prebuild-install: 7.1.1
     dev: true
     optional: true
+
+  /lefthook-darwin-arm64@1.5.2:
+    resolution: {integrity: sha512-uyYEgj4GTytw3g2mMkPBoGAxSYscEqm6yQVuYDcuwE2Ns6+E997KMxVhFXIg+w76zIVmwfBc3ZwP0Ga9Xr1TJQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-darwin-x64@1.5.2:
+    resolution: {integrity: sha512-7l6mZ9TGbkLxozN0XHn+io4c9TQIUwT7hOJFAEW7sjKtrmPNLaf+xnATiqSD2DEbG6y6x4n8WF/j95FqkjcZLg==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-freebsd-arm64@1.5.2:
+    resolution: {integrity: sha512-7CqflCMajTEo//gUbwjNpxZYeT+BhPW65RosKfGyOG4jRq1aqW8AoLutu+vx0wsFn/M+S7lcnyxmGWtXur6+mw==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-freebsd-x64@1.5.2:
+    resolution: {integrity: sha512-D6bEvOqipu/NyTTHvjnwGw/2Y03SQhWqs/pUwJOKrb/Za4T91i3fu8ULn4jyafn7Svm1iI/l8EpGPFuzbiaFvQ==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-linux-arm64@1.5.2:
+    resolution: {integrity: sha512-tCfF92enT/RwfWVYxhlCxSnutGuqOkIM0XqoPcQEHJuWIEvaFgZ2VgNnfBTusOffVMGd1Ue2ouU4Z77ZZ8TH0Q==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-linux-x64@1.5.2:
+    resolution: {integrity: sha512-rZeYS7LcLRJAYZsYzS7/uKCQwnNf7clyhpWADIyyIXj73SX3QoF0wBrCMHUMa72zpRsbIu5Sz/SYiTKCcUGU0w==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-windows-arm64@1.5.2:
+    resolution: {integrity: sha512-jT8Nc5eOfsf1uGYjodODtIEEOEOxvu6GnOPwpvlWwAG693abA+eocdjRB855sa1RR4CekmcKXi7/1E6iVHzY5A==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook-windows-x64@1.5.2:
+    resolution: {integrity: sha512-tPN0957RhpPC74aUTDk6+wYcU46K2js6oQcLipurQJvD5LAsS8h2HcXePBnsiLQjpOcRt0aLWHQnNS7ilTxVPw==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lefthook@1.5.2:
+    resolution: {integrity: sha512-pksQpriXJArZ5AsSztkFbBVHyttGgQ1tqiUkAWlLKBwqSV/KJdOkS+c/yWo75QB88TgvWyypYWvpUgpqUKlBKQ==}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.5.2
+      lefthook-darwin-x64: 1.5.2
+      lefthook-freebsd-arm64: 1.5.2
+      lefthook-freebsd-x64: 1.5.2
+      lefthook-linux-arm64: 1.5.2
+      lefthook-linux-x64: 1.5.2
+      lefthook-windows-arm64: 1.5.2
+      lefthook-windows-x64: 1.5.2
+    dev: true
 
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}


### PR DESCRIPTION
This PR sets up `lefthook` to run pre-commit scripts automatically.

This only runs `biome check` on staged files to ensure they are correctly formatted and linted.

Fixes #9 