### PR TITLE
feat: handle stable and nightly version installed together

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ export async function activate(context: ExtensionContext) {
 	// we abort activation of the stable version.
 	if (context.extension.id === "biomejs.biome") {
 		const nightlyExtension = extensions.getExtension("biomejs.biome-nightly");
-		if (nightlyExtension) {
+		if (nightlyExtension.isActive) {
 			outputChannel.appendLine(
 				"Biome Nightly detected, disabling Biome extension",
 			);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
 	TextEditor,
 	Uri,
 	commands,
+	extensions,
 	languages,
 	window,
 	workspace,
@@ -41,6 +42,18 @@ const IN_BIOME_PROJECT = "inBiomeProject";
 export async function activate(context: ExtensionContext) {
 	const outputChannel = window.createOutputChannel("Biome");
 	const traceOutputChannel = window.createOutputChannel("Biome Trace");
+
+	// If this extension is a stable version and a nightly version is installed,
+	// we abort activation of the stable version.
+	if (context.extension.id === "biomejs.biome") {
+		const nightlyExtension = extensions.getExtension("biomejs.biome-nightly");
+		if (nightlyExtension) {
+			outputChannel.appendLine(
+				"Biome Nightly detected, disabling Biome extension",
+			);
+			return;
+		}
+	}
 
 	const requiresConfiguration = workspace
 		.getConfiguration("biome")

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,8 +43,8 @@ export async function activate(context: ExtensionContext) {
 	const outputChannel = window.createOutputChannel("Biome");
 	const traceOutputChannel = window.createOutputChannel("Biome Trace");
 
-	// If this extension is a stable version and a nightly version is installed,
-	// we abort activation of the stable version.
+	// If this extension is a stable version and a nightly version is installed
+	// and active, we abort activation of the stable version.
 	if (context.extension.id === "biomejs.biome") {
 		const nightlyExtension = extensions.getExtension("biomejs.biome-nightly");
 		if (nightlyExtension.isActive) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ export async function activate(context: ExtensionContext) {
 	// and active, we abort activation of the stable version.
 	if (context.extension.id === "biomejs.biome") {
 		const nightlyExtension = extensions.getExtension("biomejs.biome-nightly");
-		if (nightlyExtension.isActive) {
+		if (nightlyExtension?.isActive) {
 			outputChannel.appendLine(
 				"Biome Nightly detected, disabling Biome extension",
 			);


### PR DESCRIPTION
This PR adds a short-circuit mechanism to abort the activation of a stable version when a nightly version is installed in parallel and active.