### PR TITLE
Docs: Fix typo `Thhis` on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can also format a selection of text by following the steps below.
 
 #### Formatting on save
 
-Thhis supports formatting on save out of the box. You should enable
+This supports formatting on save out of the box. You should enable
 format on save in your editor's settings and make sure that the Biome extension is [set as the
 default formatter](#setting-as-the-default-formatter) for your documents/languages.
 


### PR DESCRIPTION
Description:
Change `Thhis` to `This` in [README.md](https://github.com/biomejs/biome-vscode/blob/main/README.md). 