### PR TITLE
feat: allow formatting and linting of in-memory files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -119,12 +119,12 @@ export async function activate(context: ExtensionContext) {
 	await statusBar.setUsingBundledBiome(server.bundled);
 
 	const documentSelector: DocumentFilter[] = [
-		{ language: "javascript", scheme: "file" },
-		{ language: "typescript", scheme: "file" },
-		{ language: "javascriptreact", scheme: "file" },
-		{ language: "typescriptreact", scheme: "file" },
-		{ language: "json", scheme: "file" },
-		{ language: "jsonc", scheme: "file" },
+		{ language: "javascript" },
+		{ language: "typescript" },
+		{ language: "javascriptreact" },
+		{ language: "typescriptreact" },
+		{ language: "json" },
+		{ language: "jsonc" },
 	];
 
 	const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
This PR loosens the constraints of the document filter to allow linting and formatting in-memory files.

Related to https://github.com/biomejs/biome/pull/1413

---

Fixes https://github.com/biomejs/biome-vscode/issues/35