### PR TITLE
fix: handle versions list fetch failures

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -103,7 +103,7 @@ export async function activate(context: ExtensionContext) {
 		);
 
 		if (action === "Download Biome") {
-			if (!(await selectAndDownload(context))) {
+			if (!(await selectAndDownload(context, outputChannel))) {
 				return;
 			}
 		}
@@ -115,7 +115,7 @@ export async function activate(context: ExtensionContext) {
 		}
 	}
 
-	const statusBar = new StatusBar(context);
+	const statusBar = new StatusBar(context, outputChannel);
 	await statusBar.setUsingBundledBiome(server.bundled);
 
 	const documentSelector: DocumentFilter[] = [
@@ -228,14 +228,14 @@ export async function activate(context: ExtensionContext) {
 		);
 
 		if (result === "Update") {
-			await updateToLatest(context);
-			statusBar.checkForUpdates();
+			await updateToLatest(context, outputChannel);
+			statusBar.checkForUpdates(outputChannel);
 		}
 	});
 
 	commands.registerCommand(Commands.ChangeVersion, async () => {
 		await selectAndDownload(context);
-		statusBar.checkForUpdates();
+		statusBar.checkForUpdates(outputChannel);
 	});
 
 	session.registerCommand(Commands.SyntaxTree, syntaxTree(session));

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,6 +1,7 @@
 import { gt } from "semver";
 import {
 	ExtensionContext,
+	OutputChannel,
 	StatusBarAlignment,
 	StatusBarItem,
 	ThemeColor,
@@ -37,7 +38,10 @@ export class StatusBar {
 	private isActive = false;
 	private serverVersion = "";
 
-	constructor(private readonly context: ExtensionContext) {
+	constructor(
+		private readonly context: ExtensionContext,
+		private readonly outputChannel?: OutputChannel,
+	) {
 		this.statusBarItem = window.createStatusBarItem(
 			"biome.status",
 			StatusBarAlignment.Right,
@@ -54,7 +58,7 @@ export class StatusBar {
 		);
 
 		this.update();
-		this.checkForUpdates();
+		this.checkForUpdates(outputChannel);
 	}
 
 	public setServerState(client: LanguageClient, state: State) {
@@ -164,17 +168,17 @@ export class StatusBar {
 
 	public async setUsingBundledBiome(usingBundledBiome: boolean) {
 		this.usingBundledBiome = usingBundledBiome;
-		await this.checkForUpdates();
+		await this.checkForUpdates(this.outputChannel);
 	}
 
-	public async checkForUpdates() {
+	public async checkForUpdates(outputChannel?: OutputChannel) {
 		// Only check for updates if we're using the bundled version
 		if (!this.usingBundledBiome) {
 			this.statusBarUpdateItem.hide();
 			return;
 		}
 
-		const latestVersion = (await getVersions(this.context))?.[0];
+		const latestVersion = (await getVersions(this.context, outputChannel))?.[0];
 
 		// If the latest version cannot be fetch, do not display the update
 		// status bar item.


### PR DESCRIPTION
This PR addresses issues that could arise when hitting the GitHub API rate limit.

When hitting the rate limit, the extension will now continue instead of crashing.

Additionally, some logging has been added when this happens so we can better troubleshoot it in the future.

Closes https://github.com/biomejs/biome-vscode/issues/56
Supersedes https://github.com/biomejs/biome-vscode/pull/57