### PR TITLE
fix: filter out unhandled schemes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -119,12 +119,18 @@ export async function activate(context: ExtensionContext) {
 	await statusBar.setUsingBundledBiome(server.bundled);
 
 	const documentSelector: DocumentFilter[] = [
-		{ language: "javascript" },
-		{ language: "typescript" },
-		{ language: "javascriptreact" },
-		{ language: "typescriptreact" },
-		{ language: "json" },
-		{ language: "jsonc" },
+		{ language: "javascript", scheme: "file" },
+		{ language: "javascript", scheme: "untitled" },
+		{ language: "typescript", scheme: "file" },
+		{ language: "typescript", scheme: "untitled" },
+		{ language: "javascriptreact", scheme: "file" },
+		{ language: "javascriptreact", scheme: "untitled" },
+		{ language: "typescriptreact", scheme: "file" },
+		{ language: "typescriptreact", scheme: "untitled" },
+		{ language: "json", scheme: "file" },
+		{ language: "json", scheme: "untitled" },
+		{ language: "jsonc", scheme: "file" },
+		{ language: "jsonc", scheme: "untitled" },
 	];
 
 	const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
This PR fixes an issue brought to our attention by @utrolig, where the extension sends error notifications to the user after showing the diff editor.

In the latest version, we slightly changed the document filter to allow formatting and linting of untitled files. In doing so, we've let unwanted schemes be passed to Biome, and in this case, it passes files with the git scheme, which Biome does not handle.

The solution here is to add additional document filters and explicitly list the schemes we support instead of leaving them unspecified.