### PR TITLE
chore: stop using `null` for settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,13 +84,11 @@
 					"description": "Traces the communication between VS Code and the language server."
 				},
 				"biome.lspBin": {
-					"type": ["string", "null"],
-					"default": null,
+					"type": "string",
 					"markdownDescription": "The biome lsp server executable. If the path is relative, the workspace folder will be used as base path"
 				},
 				"biome.rename": {
-					"type": ["boolean", "null"],
-					"default": null,
+					"type": "boolean",
 					"markdownDescription": "Enable/Disable Biome handling renames in the workspace. (Experimental)"
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 				"biome.lspBin": {
 					"type": "string",
 					"default": "",
-          "ignoreSync": true,
+					"ignoreSync": true,
 					"markdownDescription": "The biome lsp server executable. If the path is relative, the workspace folder will be used as base path"
 				},
 				"biome.rename": {

--- a/package.json
+++ b/package.json
@@ -85,10 +85,12 @@
 				},
 				"biome.lspBin": {
 					"type": "string",
+					"default": "",
 					"markdownDescription": "The biome lsp server executable. If the path is relative, the workspace folder will be used as base path"
 				},
 				"biome.rename": {
 					"type": "boolean",
+					"default": false,
 					"markdownDescription": "Enable/Disable Biome handling renames in the workspace. (Experimental)"
 				}
 			}

--- a/src/main.ts
+++ b/src/main.ts
@@ -349,8 +349,8 @@ async function getServerPath(
 	}
 
 	const config = workspace.getConfiguration();
-	const explicitPath = config.get("biome.lspBin");
-	if (typeof explicitPath === "string" && explicitPath !== "") {
+	const explicitPath: string = config.get("biome.lspBin");
+	if (explicitPath !== "") {
 		return {
 			bundled: false,
 			workspaceDependency: false,


### PR DESCRIPTION
Best practice