### PR TITLE
chore: normalize `contributes.configuration.properties` order and ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Set the `editor.defaultFormatter` to `biomejs.biome` for the desired language. F
 To resolve the location of the `biome` binary, the extension will look into the following places, in order:
 
 1. The project's local dependencies (`node_modules`)
-2. The path specified in the `biome.lspBin` configuration option of the extension
+2. The path specified in the `biome.LSP.bin` configuration option of the extension
 3. The extension's `globalStorage` location
 
 If none of these locations has a `biome` binary, the extension will prompt you to download a binary compatible with your operating system and architecture and store it in the `globalStorage`.
@@ -124,9 +124,9 @@ To automatically sort imports on save, add the following to your editor configur
 
 ## Extension Settings
 
-### `biome.lspBin`
+### `biome.LSP.bin`
 
-The `biome.lspBin` option overrides the Biome binary used by the extension.
+The `biome.LSP.bin` option overrides the Biome binary used by the extension.
 The workspace folder is used as the base path if the path is relative.
 
 ### `biome.rename`

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	"capabilities": {
 		"untrustedWorkspaces": {
 			"supported": "limited",
-			"restrictedConfigurations": ["biome.lspBin"]
+			"restrictedConfigurations": ["biome.LSP.bin"]
 		}
 	},
 	"contributes": {
@@ -75,23 +75,23 @@
 			"title": "Biome",
 			"type": "object",
 			"properties": {
-				"biome_lsp.trace.server": {
+				"biome.rename": {
+					"type": ["boolean", "null"],
+					"default": null,
+					"markdownDescription": "Enable/Disable Biome handling renames in the workspace. (Experimental)"
+				},
+				"biome.LSP.bin": {
+					"type": ["string", "null"],
+					"default": null,
+					"markdownDescription": "The biome lsp server executable. If the path is relative, the workspace folder will be used as base path"
+				},
+				"biome.LSP.trace": {
 					"type": "string",
 					"scope": "window",
 					"enum": ["off", "messages", "verbose"],
 					"enumDescriptions": ["No traces", "Error only", "Full log"],
 					"default": "off",
 					"description": "Traces the communication between VS Code and the language server."
-				},
-				"biome.lspBin": {
-					"type": ["string", "null"],
-					"default": null,
-					"markdownDescription": "The biome lsp server executable. If the path is relative, the workspace folder will be used as base path"
-				},
-				"biome.rename": {
-					"type": ["boolean", "null"],
-					"default": null,
-					"markdownDescription": "Enable/Disable Biome handling renames in the workspace. (Experimental)"
 				}
 			}
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -349,7 +349,7 @@ async function getServerPath(
 	}
 
 	const config = workspace.getConfiguration();
-	const explicitPath = config.get("biome.lspBin");
+	const explicitPath = config.get("biome.LSP.bin");
 	if (typeof explicitPath === "string" && explicitPath !== "") {
 		return {
 			bundled: false,


### PR DESCRIPTION
I am not sure why there is a "LSP" property category in the first place since it's all about biome LSP, so maybe it would be best to have
- `biome.bin`
- `biome.log`
- `biome.rename`