### PR TITLE
chore: remove Extension Settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,14 +121,3 @@ To automatically sort imports on save, add the following to your editor configur
   }
 }
 ```
-
-## Extension Settings
-
-### `biome.lspBin`
-
-The `biome.lspBin` option overrides the Biome binary used by the extension.
-The workspace folder is used as the base path if the path is relative.
-
-### `biome.rename`
-
-Enables Biome to handle renames in the workspace (experimental).


### PR DESCRIPTION
## Rationale

[contribution points](https://code.visualstudio.com/api/references/contribution-points) are available in the extension marketplace page
<img width="1280" alt="image" src="https://github.com/biomejs/biome-vscode/assets/76160668/5871d4de-0ca9-4c44-8b13-e0b65087bc47">