### PR TITLE
fix: scan workspace folders until biome is found

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -411,10 +411,10 @@ async function getWorkspaceDependency(
 				return biomePath.fsPath;
 			}
 		} catch {
-			return undefined;
+			outputChannel.appendLine(
+				`Could not resolve Biome in the dependencies of workspace folder: ${workspaceFolder.uri.fsPath}`,
+			);
 		}
-
-		return undefined;
 	}
 
 	return undefined;


### PR DESCRIPTION
### Summary

This PR fixes an issue where Biome cannot be found from a workspace folder's dependencies if it's not the first workspace in the list.

### Details

When opening a VS Code workspace with multiple folders, the extension would loop through the list of workspace folders to locate the biome binary in the workspace's dependencies.

Unfortunately, a logic error prevented the extension from looking past the first workspace folder, which meant that depending on the folders' order, the extension could not locate Biome correctly.