### PR TITLE
feat: search for `biome` in PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 				"biome.searchInPath": {
 					"type": "boolean",
 					"default": true,
-					"markdownDescription": "Whether to search for the biome executable in the PATH environment variable"
+					"markdownDescription": "Whether to search for the biome executable in the folders declared in the PATH environment variable"
 				},
 				"biome.rename": {
 					"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
 					"ignoreSync": true,
 					"markdownDescription": "The biome lsp server executable. If the path is relative, the workspace folder will be used as base path"
 				},
+				"biome.searchInPath": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Whether to search for the biome executable in the PATH environment variable"
+				},
 				"biome.rename": {
 					"type": "boolean",
 					"default": false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -417,7 +417,6 @@ async function findBiomeInPath(): Promise<Uri | undefined> {
 			Uri.file(dir),
 			`biome${process.platform === "win32" ? ".exe" : ""}`,
 		);
-		console.log(biome.fsPath);
 		if (await fileExists(biome)) {
 			return biome;
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -413,7 +413,11 @@ async function findBiomeInPath(): Promise<Uri | undefined> {
 	}
 
 	for (const dir of path.split(delimiter)) {
-		const biome = Uri.joinPath(Uri.parse(dir), "biome");
+		const biome = Uri.joinPath(
+			Uri.file(dir),
+			`biome${process.platform === "win32" ? ".exe" : ""}`,
+		);
+		console.log(biome.fsPath);
 		if (await fileExists(biome)) {
 			return biome;
 		}


### PR DESCRIPTION
This PR introduces a new feature to allow searching for the biome binary in the PATH.

Here's where it comes in the current detection order.

1. Search in `DEBUG_SERVER_PATH`
2. Look in `biome.lspBin`
3. Look in project's dependencies
4. **Search in PATH**
5. Download global binary

### Tests

- [x] macOS
- [x] Linux
- [x] Windows

Possible fix for #127
