### PR TITLE
feat: add Yarn PnP support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -404,9 +404,9 @@ async function getWorkspaceDependency(
 				`Looks like a Yarn PnP workspace: ${workspaceFolder.uri.fsPath}`,
 			);
 			try {
-				const pnpApi = require(
-					Uri.joinPath(workspaceFolder.uri, ".pnp.cjs").fsPath,
-				);
+				const pnpApi = (
+					await import(Uri.joinPath(workspaceFolder.uri, ".pnp.cjs").fsPath)
+				).default;
 				const pkgPath = pnpApi.resolveRequest(
 					"@biomejs/biome/package.json",
 					workspaceFolder.uri.fsPath,

--- a/src/main.ts
+++ b/src/main.ts
@@ -397,7 +397,7 @@ async function getWorkspaceDependency(
 	outputChannel: OutputChannel,
 ): Promise<string | undefined> {
 	for (const workspaceFolder of workspace.workspaceFolders ?? []) {
-		// Check for Yarn PnP and try reolving the Biome binary without a node_modules
+		// Check for Yarn PnP and try resolving the Biome binary without a node_modules
 		// folder first.
 		if (await fileExists(Uri.joinPath(workspaceFolder.uri, ".pnp.cjs"))) {
 			outputChannel.appendLine(

--- a/src/main.ts
+++ b/src/main.ts
@@ -409,15 +409,17 @@ async function getWorkspaceDependency(
 				`Looks like a Yarn PnP workspace: ${workspaceFolder.uri.fsPath}`,
 			);
 			try {
-				const { resolveRequest } = (await import(pnpFile.fsPath)).default;
-				const pkgPath = resolveRequest(
+				const pnpApi = require(
+					Uri.joinPath(workspaceFolder.uri, ".pnp.cjs").fsPath,
+				);
+				const pkgPath = pnpApi.resolveRequest(
 					"@biomejs/biome/package.json",
 					workspaceFolder.uri.fsPath,
 				);
 				if (!pkgPath) {
 					throw new Error("No @biomejs/biome dependency configured");
 				}
-				return resolveRequest(
+				return pnpApi.resolveRequest(
 					`@biomejs/cli-${process.platform}-${process.arch}/biome${
 						process.platform === "win32" ? ".exe" : ""
 					}`,


### PR DESCRIPTION
This PR adds support for using Yarn's PnP linker when resolving the path of the `biome` binary to use.