### PR TITLE
feat: add `astro`, `vue`, and `svelte` support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -133,6 +133,12 @@ export async function activate(context: ExtensionContext) {
 		{ language: "json", scheme: "untitled" },
 		{ language: "jsonc", scheme: "file" },
 		{ language: "jsonc", scheme: "untitled" },
+		{ language: "astro", scheme: "file" },
+		{ language: "astro", scheme: "untitled" },
+		{ language: "vue", scheme: "file" },
+		{ language: "vue", scheme: "untitled" },
+		{ language: "svelte", scheme: "file" },
+		{ language: "svelte", scheme: "untitled" },
 	];
 
 	const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
### Summary

This PR adds the `astro`, `vue`, and `svelte` languages to the document filters so that they can be passed to the Biome LSP.

### Description

The upcoming version of Biome introduces partial support for formatting frontmatter in Astro files and `script` blocks of Vue and Svelte components. This PR updates the list of document filters so that the Biome LSP takes these new file types into consideration.

### Limitations

Document filters that reference `vue`, `svelte`, or `astro` will only work if an extension designed to handle these files is installed.

I do not expect this to be an issue, because it's fairly safe to assume that users of Astro, Vue and Svelte already use their respective VS Code extensions, which register their language identifiers.

### Related Issue

This PR closes #140 

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS