### PR TITLE
ci: add a workflow for linting pr titles

### DIFF
--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -1,0 +1,66 @@
+name: "Lint Pull Request Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline-delimited).
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            fix
+            feat
+            chore
+            ci
+            docs
+            refactor
+            release
+            test
+            revert
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure which scopes are disallowed in PR titles (newline-delimited).
+          # For instance by setting the value below, `chore(release): ...` (lowercase)
+          # and `ci(e2e,release): ...` (unknown scope) will be rejected.
+          # These are regex patterns auto-wrapped in `^ $`.
+          disallowScopes: |
+            release
+            [A-Z]+
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # If the PR contains one of these newline-delimited labels, the
+          # validation is skipped. If you want to rerun the validation when
+          # labels change, you might want to use the `labeled` and `unlabeled`
+          # event triggers in your workflow.
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -1,4 +1,4 @@
-name: "Lint Pull Request Title"
+name: "Lint Pull Request Titles"
 
 on:
   pull_request_target:

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -58,9 +58,3 @@ jobs:
           ignoreLabels: |
             bot
             ignore-semantic-pull-request
-
-      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: pr-title-lint-error
-          delete: true


### PR DESCRIPTION
### Summary

This PR adds a workflow for linting pr titles. It uses [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request), used by some repositories ([Electron](https://github.com/electron/electron) · [Vite](https://github.com/vitejs/vite) · [Excalidraw](https://github.com/excalidraw/excalidraw) · [Apache](https://github.com/apache/pulsar) · [Vercel](https://github.com/vercel/ncc) · [Microsoft](https://github.com/microsoft/SynapseML) · [Firebase](https://github.com/firebase/flutterfire) · [AWS](https://github.com/aws-ia/terraform-aws-eks-blueprints)).

### Description

This is definition of each part.
```
feat(ui): Add `Button` component
^    ^    ^
|    |    |__ Subject
|    |_______ Scope
|____________ Type
```

I only added some types.
- fix
- feat
- chore
- ci
- docs
- refactor
- release
- test
- revert (we don't need this?)

No scope and subject pattern. Scope will be needed in biomejs/biome repo.

### Valid
```txt
fix: Correct typo
feat: Add support for Node.js 18
refactor!: Drop support for Node.js 12
feat(ui): Add Button component
```

### Invalid
```
Correct typo
wip: Add support for Node.js 18
```
### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [x] I have tested my forked repository to check if the workflow works
- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [ ] macOS