### PR TITLE
feat: enable extension for CSS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "biomejs",
 	"displayName": "Biome",
 	"description": "Biome LSP VS Code Extension",
-	"version": "2.2.3",
+	"version": "2.2.2",
 	"icon": "resources/icons/icon.png",
 	"activationEvents": [
 		"onLanguage:javascript",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "biomejs",
 	"displayName": "Biome",
 	"description": "Biome LSP VS Code Extension",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"icon": "resources/icons/icon.png",
 	"activationEvents": [
 		"onLanguage:javascript",
@@ -14,7 +14,8 @@
 		"onLanguage:jsonc",
 		"onLanguage:vue",
 		"onLanguage:astro",
-		"onLanguage:svelte"
+		"onLanguage:svelte",
+		"onLanguage:css"
 	],
 	"main": "./out/main.js",
 	"homepage": "https://github.com/biomejs/biome-vscode",

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,6 +117,8 @@ export async function activate(context: ExtensionContext) {
 		{ language: "vue", scheme: "untitled" },
 		{ language: "svelte", scheme: "file" },
 		{ language: "svelte", scheme: "untitled" },
+		{ language: "css", scheme: "file" },
+		{ language: "css", scheme: "untitled" },
 	];
 
 	const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
### Summary

The PR enables the extension for CSS files. 

### Description

I had a couple of issues, not sure if they are relevant:
- `bun` updated the lock file, not sure why. I didn't add it to the commit though 
- When debugging the extension using `F5`, the extension didn't trigger for the CSS files. Is it expected?
- lefthook triggered when committing, and if it failed 
	```
	┃  check ❯ 
	
	sh: biome: command not found
	```

This feature should be released after (together) with the release of v1.8.
<!-- Describe your changes in detail -->

### Related Issue

N/A

<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS