### PR TITLE
fix: musl libc detection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -267,50 +267,6 @@ export async function activate(context: ExtensionContext) {
 	await client.start();
 }
 
-type Architecture = "x64" | "arm64";
-
-type PlatformTriplets = {
-	[P in NodeJS.Platform]?: {
-		[A in Architecture]: {
-			triplet: string;
-			package: string;
-		};
-	};
-};
-
-const PLATFORMS: PlatformTriplets = {
-	win32: {
-		x64: {
-			triplet: "x86_64-pc-windows-msvc",
-			package: "@biomejs/cli-win32-x64",
-		},
-		arm64: {
-			triplet: "aarch64-pc-windows-msvc",
-			package: "@biomejs/cli-win32-arm64",
-		},
-	},
-	darwin: {
-		x64: {
-			triplet: "x86_64-apple-darwin",
-			package: "@biomejs/cli-darwin-x64",
-		},
-		arm64: {
-			triplet: "aarch64-apple-darwin",
-			package: "@biomejs/cli-darwin-arm64",
-		},
-	},
-	linux: {
-		x64: {
-			triplet: "x86_64-unknown-linux-gnu",
-			package: "@biomejs/cli-linux-x64",
-		},
-		arm64: {
-			triplet: "aarch64-unknown-linux-gnu",
-			package: "@biomejs/cli-linux-arm64",
-		},
-	},
-};
-
 async function getServerPath(
 	context: ExtensionContext,
 	outputChannel: OutputChannel,

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import { syntaxTree } from "./commands/syntaxTree";
 import { selectAndDownload, updateToLatest } from "./downloader";
 import { Session } from "./session";
 import { StatusBar } from "./statusBar";
-import { setContextValue } from "./utils";
+import { isMusl, setContextValue } from "./utils";
 
 let client: LanguageClient;
 
@@ -395,6 +395,8 @@ async function getWorkspaceRelativePath(path: string) {
 async function getWorkspaceDependency(
 	outputChannel: OutputChannel,
 ): Promise<string | undefined> {
+	const wantsMuslBuild = isMusl();
+
 	for (const workspaceFolder of workspace.workspaceFolders ?? []) {
 		// Check for Yarn PnP and try resolving the Biome binary without a node_modules
 		// folder first.
@@ -419,9 +421,9 @@ async function getWorkspaceDependency(
 					throw new Error("No @biomejs/biome dependency configured");
 				}
 				return pnpApi.resolveRequest(
-					`@biomejs/cli-${process.platform}-${process.arch}/biome${
-						process.platform === "win32" ? ".exe" : ""
-					}`,
+					`@biomejs/cli-${process.platform}-${process.arch}${
+						wantsMuslBuild ? "-musl" : ""
+					}/biome${process.platform === "win32" ? ".exe" : ""}`,
 					pkgPath,
 				);
 			} catch (err) {
@@ -443,7 +445,9 @@ async function getWorkspaceDependency(
 			);
 			const binaryPackage = dirname(
 				requireFromBiome.resolve(
-					`@biomejs/cli-${process.platform}-${process.arch}/package.json`,
+					`@biomejs/cli-${process.platform}-${process.arch}${
+						wantsMuslBuild ? "-musl" : ""
+					}/package.json`,
 				),
 			);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { spawn, spawnSync } from "node:child_process";
 import { type TextDocument, type TextEditor, commands } from "vscode";
 
 const SUPPORTED_LANGUAGES = new Set(["javascript", "typescript"]);
@@ -23,4 +24,27 @@ export function isBiomeDocument(document: TextDocument) {
 
 export function isBiomeEditor(editor: TextEditor): editor is BiomeEditor {
 	return isBiomeDocument(editor.document);
+}
+
+/**
+ * Determines if the current system is using musl libc
+ *
+ * On Linux, the output of the `ldd --version` command will contain the string `musl`
+ * if the system is using musl libc.
+ *
+ * On non-Linux systems, the function will return false.
+ *
+ * @returns boolean
+ */
+export function isMusl() {
+	if (process.platform !== "linux") {
+		return false;
+	}
+
+	try {
+		const output = spawnSync("ldd", ["--version"], { encoding: "utf8" });
+		return output.stdout.includes("musl");
+	} catch {
+		return false;
+	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { type TextDocument, type TextEditor, commands } from "vscode";
 
 const SUPPORTED_LANGUAGES = new Set(["javascript", "typescript"]);


### PR DESCRIPTION
### Summary

This PR fixes the musl libc detection, allowing the extension to select the correct biome binary from the project's dependencies.

### Related Issue

This PR closes #223 

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [x] I have tested my changes on the following platforms:
  - [x] Windows
  - [x] Linux
  - [x] macOS