### PR TITLE
ci: fix lint pr title as following biomejs/biome

### DIFF
--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -15,46 +15,44 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@cfb60706e18bc85e8aec535e3c577abe8f70378e # v5.5.2
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Configure which types are allowed (newline-delimited).
-          # Default: https://github.com/commitizen/conventional-commit-types
+          # ref: CONTRIBUTING.md
           types: |
-            fix
-            feat
+            build
             chore
             ci
             docs
+            feat
+            fix
+            perf
             refactor
             release
-            test
             revert
+            test
           # Configure that a scope must always be provided.
           requireScope: false
-          # Configure which scopes are disallowed in PR titles (newline-delimited).
-          # For instance by setting the value below, `chore(release): ...` (lowercase)
-          # and `ci(e2e,release): ...` (unknown scope) will be rejected.
+          # Configure which scopes are disallowed in PR titles.
           # These are regex patterns auto-wrapped in `^ $`.
+          #
+          # We disable the following scopes:
+          # - `release` because we have the `release` type
+          # - UPPERCASE titles because we promote the use of lowercase
           disallowScopes: |
             release
-            [A-Z]+
+            [A-Z_-]+
           # Configure additional validation for the subject based on a regex.
-          # This example ensures the subject doesn't start with an uppercase character.
-          subjectPattern: ^(?![A-Z]).+$
+          # Ensures that the subject doesn't start with an uppercase character.
+          subjectPattern: ^[^A-Z].*$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
-            didn't match the configured pattern. Please ensure that the subject
-            doesn't start with an uppercase character.
-          # If the PR contains one of these newline-delimited labels, the
-          # validation is skipped. If you want to rerun the validation when
-          # labels change, you might want to use the `labeled` and `unlabeled`
-          # event triggers in your workflow.
-          ignoreLabels: |
-            bot
-            ignore-semantic-pull-request
+            didn't match the configured pattern.
+            Please ensure that the subject doesn't start with an uppercase character.
+            The scope should not be in UPPERCASE.


### PR DESCRIPTION
### Summary

<!-- Provide a general summary of your changes -->

This PR changes `lint-pr-title` workflow to the same as it in `biomejs/biome`.


### Related Issue

nothing

<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>

### Checklist

<!-- Please check the platforms you have tested this change on -->

This is only CI change.


- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [ ] macOS