### PR TITLE
refactor: reduce `@ts-expect-error` and more type safe

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -28,7 +28,7 @@ export const selectAndDownload = async (
 	);
 
 	if (!versions) {
-		return;
+		return undefined;
 	}
 
 	const version = await askVersion(versions);

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -28,7 +28,7 @@ export const selectAndDownload = async (
 	);
 
 	if (!versions) {
-		return undefined;
+		return;
 	}
 
 	const version = await askVersion(versions);


### PR DESCRIPTION
### Summary

Refactor to remove `@ts-expect-error`

<!-- Provide a general summary of your changes -->

### Description

<!-- Describe your changes in detail -->

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS