### PR TITLE
chore: update template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug-report.yaml
@@ -68,6 +68,9 @@ body:
   - type: textarea
     attributes:
       label: "Logs"
-      description: If applicable, include the biome trace logs. To find these logs, open the output panel and select the Biome Trace category. Try to only include the logs that are relevant to the issue.
+      description: | 
+        If applicable, include the biome trace logs. To find these logs, open the output panel and select the Biome Trace category. Try to only include the logs that are relevant to the issue.
+        
+        Alternatively, if you have the CLI installed, you can run `biome rage --daemon-logs` to retrieve the logs emitted by the daemon. Usually, these logs contain more information, but they are way more verbose.
       render: plain text
       placeholder: "Biome trace logs can be found in the output panel under the Biome Trace category"


### PR DESCRIPTION
### Summary

Update bug report template

### Description

We tell users to use the Trace output, but that doesn't give us much information, usually. However, the users can use `biome rage --daemon-logs`, which output the LSP logs of the daemon.