### PR TITLE
Feat Proposal: Check for biome config file on startup 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,13 +26,20 @@ import { syntaxTree } from "./commands/syntaxTree";
 import { selectAndDownload, updateToLatest } from "./downloader";
 import { Session } from "./session";
 import { StatusBar } from "./statusBar";
-import { isMusl, setContextValue } from "./utils";
+import { checkForBiomeJson, isMusl, setContextValue } from "./utils";
 
 let client: LanguageClient;
 
 const IN_BIOME_PROJECT = "inBiomeProject";
 
 export async function activate(context: ExtensionContext) {
+
+	const biomeJsonExists = await checkForBiomeJson();
+	if (!biomeJsonExists) {
+		window.showWarningMessage("Biome extension is disabled because biome.json is not found in the working directory.");
+		return;
+	}
+
 	// If the extension is disabled, abort the activation.
 	if (!workspace.getConfiguration("biome").get<boolean>("enabled", true)) {
 		return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ const IN_BIOME_PROJECT = "inBiomeProject";
 
 export async function activate(context: ExtensionContext) {
 
+	// Check if biome.json exists in the workspace.
 	const biomeJsonExists = await checkForBiomeJson();
 	if (!biomeJsonExists) {
 		window.showWarningMessage("Biome extension is disabled because biome.json is not found in the working directory.");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { type TextDocument, type TextEditor, commands } from "vscode";
+import { type TextDocument, type TextEditor, commands, workspace, Uri } from "vscode";
 
 const SUPPORTED_LANGUAGES = new Set(["javascript", "typescript"]);
 
@@ -49,4 +49,17 @@ export function isMusl() {
 	} catch {
 		return false;
 	}
+}
+
+export async function checkForBiomeJson(): Promise<boolean> {
+	const folders = workspace.workspaceFolders;
+	if (!folders) return false;
+
+	for (const folder of folders) {
+		const biomeJsonPath = Uri.joinPath(folder.uri, "biome.json");
+		if (await workspace.fs.stat(biomeJsonPath.fsPath).then(() => true).catch(() => false)) {
+			return true; // File exists
+		}
+	}
+	return false; // biome.json not found in any workspace folder
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,7 @@ export function isMusl() {
 }
 
 /**
- * Checks if the current workspace has a biome.json file
+ * Checks if the current workspace has a biome.json or biome.jsonc file
  * @returns boolean
  */
 export async function checkForBiomeJson(): Promise<boolean> {
@@ -61,7 +61,12 @@ export async function checkForBiomeJson(): Promise<boolean> {
 
 	for (const folder of folders) {
 		const biomeJsonPath = Uri.joinPath(folder.uri, "biome.json");
-		if (await workspace.fs.stat(biomeJsonPath.fsPath).then(() => true).catch(() => false)) {
+		const biomeJsoncPath = Uri.joinPath(folder.uri, "biome.jsonc");
+
+		const biomeJsonExists = await workspace.fs.stat(biomeJsonPath.fsPath).then(() => true).catch(() => false);
+		const biomeJsoncExists = await workspace.fs.stat(biomeJsoncPath.fsPath).then(() => true).catch(() => false);
+
+		if (biomeJsonExists || biomeJsoncExists) {
 			return true;
 		}
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,8 +58,8 @@ export async function checkForBiomeJson(): Promise<boolean> {
 	for (const folder of folders) {
 		const biomeJsonPath = Uri.joinPath(folder.uri, "biome.json");
 		if (await workspace.fs.stat(biomeJsonPath.fsPath).then(() => true).catch(() => false)) {
-			return true; // File exists
+			return true;
 		}
 	}
-	return false; // biome.json not found in any workspace folder
+	return false;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,10 @@ export function isMusl() {
 	}
 }
 
+/**
+ * Checks if the current workspace has a biome.json file
+ * @returns boolean
+ */
 export async function checkForBiomeJson(): Promise<boolean> {
 	const folders = workspace.workspaceFolders;
 	if (!folders) return false;


### PR DESCRIPTION
### Summary

This PR is a feature proposal that started with a "bug" or rather something I dislike with the biome plugin; enabling / disabling per workspace.  

Unfortunately not every developer can migrate all legacy projects they have to biome so we are stuck with other linters/formatters, which when having the biome vscode plugin enabled, means errors showing on every project.  

I propose a check for the biome.json /.jsonc file should be done per workspace and then disabled automatically as it would otherwise be useless and take up resources.

Obviously the long term answer is migrate everything to biome or ignore people who don't use biome, however achieving that goal imo is by broad support, and in this case making the extension less of a hassle to people maintaining many projects with different linters.


### Description

Checks workspace for biome.json /.jsonc config file on plugin startup.  Disables it with a message if not found.

### Related Issue
Would fix this:
https://github.com/biomejs/biome-vscode/issues/74
or:
https://x.com/lilpropdrilla/status/1814578885683511329

This PR closes #[<issue_number>](https://github.com/biomejs/biome-vscode/issues/74)

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [ ] macOS