### PR TITLE
feat: use statically linked builds on Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please review the following guidelines before making your contribution.
 
 ## Development
 
-The extension can be started in debug mode by pressing <kbd>F5</kbd> in Visual Studio Code. This will start a watcher that automatically rebuilds the extension when you make changes and opens a new VS Code window with only the Biome extension extension loaded.
+The extension can be started in debug mode by pressing <kbd>F5</kbd> in Visual Studio Code. This will start a watcher that automatically rebuilds the extension when you make changes and opens a new VS Code window with only the Biome extension loaded.
 
 ## Making changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for your interest in contributing to this project! 
+Thank you for your interest in contributing to this project!
 
 Please review the following guidelines before making your contribution.
 
@@ -20,7 +20,7 @@ Please review the following guidelines before making your contribution.
 
 ## Development
 
-The extension can be started in debug mode by pressing <kbd>F5</kbd> in Visual Studio Code. This will start a watcher that automatically rebuilds the extension when you make changes and opens a new VS Code window with only the Biome extensione extension loaded.
+The extension can be started in debug mode by pressing <kbd>F5</kbd> in Visual Studio Code. This will start a watcher that automatically rebuilds the extension when you make changes and opens a new VS Code window with only the Biome extension extension loaded.
 
 ## Making changes
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will ensure that VS Code uses Biome to format all supported files, instead 
 If you'd rather not set Biome as the default formatter for all languages, you can set it as the default formatter for specific languages only. The following steps describe how to do this.
 
 1. Open the **Command Palette**
-2. Select _Preferences: Open User Settings (JSON)_ 
+2. Select _Preferences: Open User Settings (JSON)_
 
 Set the `editor.defaultFormatter` to `biomejs.biome` for the desired language. For example, to set Biome as the default formatter for JavaScript files, add the following to your editor's options.
 
@@ -56,7 +56,7 @@ To resolve the location of the `biome` binary, the extension will look into the 
 
 If none of these locations has a `biome` binary, the extension will prompt you to download a binary compatible with your operating system and architecture and store it in the `globalStorage`.
 
-> [!NOTE]  
+> [!NOTE]
 > We recommend adding Biome to your project's devDependencies so that both the extension and your NPM scripts use the same version of Biome.
 > ```
 > npm install -D @biomejs/biome

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -89,18 +89,16 @@ const download = async (version: string, context: ExtensionContext) => {
 		assets: { name: string; browser_download_url: string }[];
 	};
 
-	const platformArch = `${process.platform}-${process.arch}`;
+	const assetName = `biome-${process.platform}-${process.arch}${
+		process.platform === "linux" ? "-musl" : ""
+	}${process.platform === "win32" ? ".exe" : ""}`;
 
 	// Find the asset for the current platform
-	const asset = releases.assets.find(
-		(asset) =>
-			asset.name ===
-			`biome-${platformArch}${process.platform === "win32" ? ".exe" : ""}`,
-	);
+	const asset = releases.assets.find((asset) => asset.name === assetName);
 
 	if (!asset) {
 		window.showErrorMessage(
-			`The specified version is not available for your platform/architecture (${platformArch}).`,
+			`The specified version is not available for your system (${assetName}).`,
 		);
 		return;
 	}
@@ -111,7 +109,7 @@ const download = async (version: string, context: ExtensionContext) => {
 		bin = await blob.arrayBuffer();
 	} catch {
 		window.showErrorMessage(
-			`Could not download the binary for your platform/architecture (${platformArch}).`,
+			`Could not download the binary for your system (${assetName}).`,
 		);
 		return;
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import { syntaxTree } from "./commands/syntaxTree";
 import { selectAndDownload, updateToLatest } from "./downloader";
 import { Session } from "./session";
 import { StatusBar } from "./statusBar";
-import { isMusl, setContextValue } from "./utils";
+import { setContextValue } from "./utils";
 
 let client: LanguageClient;
 
@@ -395,7 +395,9 @@ async function getWorkspaceRelativePath(path: string) {
 async function getWorkspaceDependency(
 	outputChannel: OutputChannel,
 ): Promise<string | undefined> {
-	const wantsMuslBuild = isMusl();
+	const pkgFlavor = `cli-${process.platform}-${process.arch}${
+		process.platform === "linux" ? "-musl" : ""
+	}`;
 
 	for (const workspaceFolder of workspace.workspaceFolders ?? []) {
 		// Check for Yarn PnP and try resolving the Biome binary without a node_modules
@@ -421,9 +423,9 @@ async function getWorkspaceDependency(
 					throw new Error("No @biomejs/biome dependency configured");
 				}
 				return pnpApi.resolveRequest(
-					`@biomejs/cli-${process.platform}-${process.arch}${
-						wantsMuslBuild ? "-musl" : ""
-					}/biome${process.platform === "win32" ? ".exe" : ""}`,
+					`@biomejs/${pkgFlavor}/biome${
+						process.platform === "win32" ? ".exe" : ""
+					}`,
 					pkgPath,
 				);
 			} catch (err) {
@@ -444,11 +446,7 @@ async function getWorkspaceDependency(
 				}),
 			);
 			const binaryPackage = dirname(
-				requireFromBiome.resolve(
-					`@biomejs/cli-${process.platform}-${process.arch}${
-						wantsMuslBuild ? "-musl" : ""
-					}/package.json`,
-				),
+				requireFromBiome.resolve(`@biomejs/${pkgFlavor}/package.json`),
 			);
 
 			const biomePath = Uri.file(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import { type TextDocument, type TextEditor, commands } from "vscode";
 
 const SUPPORTED_LANGUAGES = new Set(["javascript", "typescript"]);
@@ -24,29 +23,4 @@ export function isBiomeDocument(document: TextDocument) {
 
 export function isBiomeEditor(editor: TextEditor): editor is BiomeEditor {
 	return isBiomeDocument(editor.document);
-}
-
-/**
- * Determines if the current system is using musl libc
- *
- * On Linux, the output of the `ldd --version` command will contain the string `musl`
- * if the system is using musl libc.
- *
- * On non-Linux systems, the function will return false.
- *
- * @returns boolean
- */
-export function isMusl() {
-	if (process.platform !== "linux") {
-		return false;
-	}
-
-	try {
-		const output = spawnSync("ldd", ["--version"], {
-			encoding: "utf8",
-		});
-		return output.stdout.includes("musl") || output.stderr.includes("musl");
-	} catch {
-		return false;
-	}
 }


### PR DESCRIPTION
### Summary

Linux will now always use -musl builds.

### Description

Linux will now always use -musl builds, which are statically built and have no external dependencies. This will make the extension more compatible across Linux systems. Additionally, I fixed a bug where the downloader would never use musl builds even when on a musl system. I also fixed a small typo.

This change will only take in effect whenever a biome binary is updated.

### Related Issue

This PR closes #295

### Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [x] Linux
  - [ ] macOS