### PR TITLE
debounce config changes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,3 +168,14 @@ export const hasVSCodeUserDataDocuments = (): boolean =>
 	) !== undefined;
 
 export const platformPackageName = `biome-${platform}`;
+
+export const debounce = <TArgs extends unknown[]>(
+	fn: (...args: TArgs) => void,
+	delay = 300,
+) => {
+	let timeout: NodeJS.Timeout | undefined;
+	return (...args: TArgs) => {
+		clearTimeout(timeout);
+		timeout = setTimeout(() => fn(...args), delay);
+	};
+};


### PR DESCRIPTION
### Summary

Debounce configuration change events so that we don't restart the extension at every keystroke.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR fixes #322 

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [ ] macOS