### PR TITLE
Fix typo in Require Config setting description

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 				},
 				"biome.requireConfigFile": {
 					"type": "boolean",
-					"markdownDescription": "Require a Biome configuration file to be present at the root of a Biome project to starts an LSP session for that project.",
+					"markdownDescription": "Require a Biome configuration file to be present at the root of a Biome project to start an LSP session for that project.",
 					"default": false,
 					"scope": "resource"
 				},


### PR DESCRIPTION
### Summary

<img width="758" alt="image" src="https://github.com/user-attachments/assets/5ea40968-2566-47ca-9eb1-bfd65f84635b">

### Description

`s/start/starts`

### Related Issue

N/A

This PR closes #<issue_number>

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [ ] macOS