### PR TITLE
feature: Add initialize project command

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,10 @@
 			{
 				"title": "Biome: Troubleshoot - Reset",
 				"command": "biome.reset"
+			},
+			{
+				"title": "Biome: Initialize Workspace",
+				"command": "biome.initializeWorkspace"
 			}
 		],
 		"configuration": {
@@ -191,7 +195,15 @@
 				"scopeName": "source.biome_syntax_tree",
 				"path": "./resources/grammars/biome-syntax-tree.tmGrammar.json"
 			}
-		]
+		],
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "biome.initializeWorkspace",
+					"when": "resourceFilename =~ /(\\.biome|biome.json|biome.jsonc)$/ || resourceFilename =~ /settings.json/"
+				}
+			]
+		}
 	},
 	"engines": {
 		"vscode": "^1.80.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import {
 } from "vscode";
 import {
 	downloadCommand,
+	initializeWorkspaceCommand,
 	resetCommand,
 	restartCommand,
 	startCommand,
@@ -52,6 +53,10 @@ const registerUserFacingCommands = () => {
 		commands.registerCommand("biome.restart", restartCommand),
 		commands.registerCommand("biome.download", downloadCommand),
 		commands.registerCommand("biome.reset", resetCommand),
+		commands.registerCommand(
+			"biome.initializeWorkspace",
+			initializeWorkspaceCommand,
+		),
 	);
 
 	info("User-facing commands registered");


### PR DESCRIPTION
### Summary

Added a command that allows you to initalize biome settings in the workspace based on this tweet:
https://x.com/colinhacks/status/1841219884287737886
and this dicussion:
https://github.com/biomejs/biome-vscode/discussions/230

### Description

when you right click on either setttings.json in .vscode or biome.json you can click on the biome: initalize workspace command to add all the required fields into settings.json for biome to work properly, also check this tweet for the merging of the config files:
https://x.com/andhaveaniceday/status/1841226098706956625

 Feel free to edit and add whatever you deem is needed here

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [x] Windows
  - [ ] Linux
  - [ ] macOS