### PR TITLE
fix global session lifecycle

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,20 @@ export const isEnabled = (folder?: WorkspaceFolder) => {
 };
 
 /**
+ * Determines whether the extension is enabled globally
+ *
+ * This function determines whether the extension is enabled globally. This is
+ * useful to conditional enable or disable functionality based on the extension's
+ * configuration at the global/user level.
+ */
+export const isEnabledGlobally = (): boolean => {
+	return (
+		workspace.getConfiguration("biome").inspect<boolean>("enabled")
+			.globalValue === true
+	);
+};
+
+/**
  * Determines whether a Biome configuration file is required in the given
  * workspace folder for the extension to start.
  */

--- a/src/session.ts
+++ b/src/session.ts
@@ -15,6 +15,7 @@ import {
 } from "vscode-languageclient/node";
 import { displayName } from "../package.json";
 import { findBiomeGlobally, findBiomeLocally } from "./binary-finder";
+import { isEnabledGlobally } from "./config";
 import { debug, error, info, error as logError, warn } from "./logger";
 import { type Project, createProjects } from "./project";
 import { state } from "./state";
@@ -170,14 +171,20 @@ export const createGlobalSessionWhenNecessary = async () => {
 
 	// If the editor has open Untitled documents, or VS Code User Data documents,
 	// we create a global session immeditaley so that the user can work with them.
-	if (hasUntitledDocuments() || hasVSCodeUserDataDocuments()) {
+	if (
+		isEnabledGlobally() &&
+		(hasUntitledDocuments() || hasVSCodeUserDataDocuments())
+	) {
 		await createGlobalSessionIfNotExists();
 	}
 
 	// Register a listener for text documents being opened so that we can create
 	// a global session if necessary.
 	workspace.onDidOpenTextDocument(async (document) => {
-		if (hasUntitledDocuments() || hasVSCodeUserDataDocuments()) {
+		if (
+			isEnabledGlobally() &&
+			(hasUntitledDocuments() || hasVSCodeUserDataDocuments())
+		) {
 			await createGlobalSessionIfNotExists();
 		}
 	});


### PR DESCRIPTION
### Summary

This PR changes the way we start the global session.

### Description

Until now, the session was always created if the window had open files that Biome could handle but did not belong to any Biome project. This included global settings files and untitled files.

Following this PR, we stop creating the global session if `biome.enabled` is set to `false` at the global/user level. We will, however, continue creating it if the extension is disabled at the workspace/workspace folder level.

### Related Issue


This PR closes #375 

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS