### PR TITLE
fix: support relative paths in `biome.lsp.bin`

### DIFF
--- a/src/binary-finder.ts
+++ b/src/binary-finder.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { delimiter } from "node:path";
 import { Uri, window } from "vscode";
+import { Utils } from "vscode-uri";
 import { config, getLspBin } from "./config";
 import {
 	platformIdentifier,
@@ -84,7 +85,9 @@ const vsCodeSettingsStrategy: LocatorStrategy = {
 				return undefined;
 			}
 
-			const biome = Uri.file(bin);
+			const resolvedBinPath = Utils.resolvePath(path, bin).toString();
+
+			const biome = Uri.file(resolvedBinPath);
 
 			if (await fileExists(biome)) {
 				return biome;


### PR DESCRIPTION
### Summary

Allow specifying relative paths in `biome.lsp.bin`.

### Description

This PR re-introduces support for specifying relative paths in `biome.lsp.bin`. The paths are relative to the project root. In case of single-root workspaces this means the root of the workspace, in monorepos, this means the root of the biome project folder.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #420 

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS