### PR TITLE
feat: lockfile glob pattern and command arg

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -2,4 +2,4 @@ pre-commit:
   commands:
     check:
       glob: "*.{js,ts,json}"
-      run: biome check --apply {staged_files} && git add {staged_files}
+      run: biome check --write {staged_files} && git add {staged_files}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,7 @@ const listenForActiveTextEditorChange = () => {
  */
 const listenForLockfilesChanges = () => {
 	const watcher = workspace.createFileSystemWatcher(
-		"**/{package-lock.json,yarn.lock,bun.lockb,pnpm-lock.yaml}",
+		"**/{package-lock.json,yarn.lock,bun.lockb,bun.lock,pnpm-lock.yaml}",
 	);
 
 	watcher.onDidChange((event) => {


### PR DESCRIPTION
### Summary

<!-- Provide a general summary of your changes -->
1. added `bun.lock' to the lockfile glob pattern
2. updated the argument for the biome check command in the lefthook.yaml

### Description

<!-- Describe your changes in detail -->
- `bun.lock` is the newly supported format for bun's lockfile
- the argument `--apply ` is deprecated


### Related Issue

<!-- If this PR is related to an issue, please link it here -->

N/A

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS