### PR TITLE
fix: do not use `musl` flavor in WSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
 	"dependencies": {
 		"@biomejs/version-utils": "0.4.0",
 		"@vscode/test-electron": "2.4.1",
+		"is-wsl": "^3.1.0",
 		"ky": "1.7.4",
 		"vscode-languageclient": "8.1.0",
 		"vscode-uri": "3.0.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@vscode/test-electron':
         specifier: 2.4.1
         version: 2.4.1
+      is-wsl:
+        specifier: ^3.1.0
+        version: 3.1.0
       ky:
         specifier: 1.7.4
         version: 1.7.4
@@ -1044,9 +1047,19 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -1065,6 +1078,10 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  is-wsl@3.1.0:
+    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+    engines: {node: '>=16'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -2517,7 +2534,13 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-docker@3.0.0: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-interactive@2.0.0: {}
 
@@ -2532,6 +2555,10 @@ snapshots:
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  is-wsl@3.1.0:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isarray@1.0.0: {}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+import isWSL from "is-wsl";
 import { workspace } from "vscode";
 
 /**
@@ -5,16 +6,21 @@ import { workspace } from "vscode";
  *
  * This constant contains the identifier of the current platform.
  *
+ * @example "linux-x64"
  * @example "linux-x64-musl"
  * @example "darwin-arm64"
  * @example "win32-x64"
  */
 export const platformIdentifier = (() => {
+	let flavor = "";
+
 	// On Linux, we always use the `musl` flavor because it has the advantage of
 	// having been built statically. This is meant to improve the compatibility
 	// with various systems such as NixOS, which handle dynamically linked
 	// binaries differently.
-	const flavor = process.platform === "linux" ? "-musl" : "";
+	if (process.platform === "linux" && !isWSL) {
+		flavor = "-musl";
+	}
 
 	return `${process.platform}-${process.arch}${flavor}`;
 })();


### PR DESCRIPTION
### Summary

This fix ensures that we do not attempt to download the `musl` variant of Biome when running inside WSL.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #486 