### PR TITLE
[2.x] fix: do not use `musl` flavor on WSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
 		"typescript": "5.5.4"
 	},
 	"dependencies": {
+		"is-wsl": "^3.1.0",
 		"resolve": "1.22.8",
 		"semver": "7.6.3",
 		"undici": "6.19.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      is-wsl:
+        specifier: ^3.1.0
+        version: 3.1.0
       resolve:
         specifier: 1.22.8
         version: 1.22.8
@@ -744,13 +747,27 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  is-wsl@3.1.0:
+    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+    engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1921,11 +1938,21 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-docker@3.0.0: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  is-wsl@3.1.0:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,4 +1,5 @@
 import { chmodSync } from "node:fs";
+import isWsl from "is-wsl";
 import { fetch } from "undici";
 import {
 	type ExtensionContext,
@@ -90,7 +91,7 @@ const download = async (version: string, context: ExtensionContext) => {
 	};
 
 	const assetName = `biome-${process.platform}-${process.arch}${
-		process.platform === "linux" ? "-musl" : ""
+		process.platform === "linux" && !isWsl ? "-musl" : ""
 	}${process.platform === "win32" ? ".exe" : ""}`;
 
 	// Find the asset for the current platform


### PR DESCRIPTION
### Summary

Backport of #487 