### PR TITLE
fix: do not force musl on linux

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -9,6 +9,7 @@ import {
 	workspace,
 } from "vscode";
 import {
+	isMusl,
 	platformSpecificAssetName,
 	platformSpecificBinaryName,
 } from "./constants";
@@ -49,8 +50,16 @@ const downloadBiomeVersion = async (
 		)
 		.json();
 
+	let assetName = platformSpecificAssetName;
+
+	// On Linux, we always want to download the musl flavor, because it's the most
+	// compatible since it's statically linked.
+	if (process.platform === "linux" && !isMusl) {
+		assetName = `${assetName}-musl`;
+	}
+
 	const asset = releases.assets.find((asset) => {
-		return asset.name === platformSpecificAssetName;
+		return asset.name === assetName;
 	});
 
 	if (!asset) {


### PR DESCRIPTION
### Summary

This PR makes it so the extension no longer looks only for `-musl` binaries on Linux

- When looking for biome in `node_modules`: use most appropriate package (`@biomejs/cli-linux-x64-musl` on systems that use musl, and `@biomejs/cli-linux-x64` on the others)
- When downloading Biome from within VS Code: always download the `-musl` flavor

### Description

Some package managers do not automatically install both the `@biomejs/cli-linux-x64` and `@biomejs/cli-linux-x64-musl`, but since our current logic expect the `-musl` flavor to be installed, some users may have trouble getting the extension to work.

This logic was initially introduced to always download the `musl` flavor when downloading Biome using the built-in downloader, but we're splitting the logic here so that we look for the most appropriate package in node modules, why still downloading the `musl` flavor when downloading Biome from VS Code.

This solves the issue because:

1. There are no expectations of compatibility put on the user when downloading Biome from VS Code. Since we use the statically built musl flavor, it just works.
2. We mitigate behavioral differences among the package managers.

### Related Issue

Fixes #502

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [x] Linux
  - [ ] macOS