### PR TITLE
chore: append activation timestamp to output channel names

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,16 @@ import isWSL from "is-wsl";
 import { workspace } from "vscode";
 
 /**
+ * Activation timestamp
+ *
+ * This constant contains the timestamp at which the extension was activated.
+ *
+ * We use this constant to generate unique identifiers for output channels to
+ * mitigate a bug in VS Code where the output channel is not cleared.
+ */
+export const activationTimestamp = Date.now();
+
+/**
  * Whether the current platform uses musl
  */
 export const isMusl = (() => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,6 @@
 import { LogLevel, window } from "vscode";
 import { displayName } from "../package.json";
+import { activationTimestamp } from "./constants";
 
 /**
  * Logger
@@ -11,9 +12,13 @@ import { displayName } from "../package.json";
  * logging verbosity, so only messages with the appropriate log level will be
  * displayed.
  */
-export const logger = window.createOutputChannel(displayName, {
-	log: true,
-});
+
+export const logger = window.createOutputChannel(
+	`${displayName} (${activationTimestamp})`,
+	{
+		log: true,
+	},
+);
 
 type LogArguments = Record<string, unknown>;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -16,7 +16,11 @@ import {
 import { displayName } from "../package.json";
 import { findBiomeGlobally, findBiomeLocally } from "./binary-finder";
 import { isEnabledGlobally } from "./config";
-import { operatingMode, supportedLanguageIdentifiers } from "./constants";
+import {
+	activationTimestamp,
+	operatingMode,
+	supportedLanguageIdentifiers,
+} from "./constants";
 import { debug, error, info, error as logError, warn } from "./logger";
 import { type Project, createProjects } from "./project";
 import { state } from "./state";
@@ -294,36 +298,7 @@ const createLspLogger = (project?: Project): LogOutputChannel => {
 	// logger name, so we just use the display name of the extension.
 	if (!project?.folder) {
 		return window.createOutputChannel(
-			`${displayName} LSP (global session)`,
-			{
-				log: true,
-			},
-		);
-	}
-
-	// If the project is present, we're creating a logger for a specific project.
-	// In this case, we display the name of the project and the relative path to
-	// the project root in the logger name. Additionally, when in a multi-root
-	// workspace, we prefix the path with the name of the workspace folder.
-	const prefix =
-		operatingMode === "multi-root" ? `${project.folder.name}::` : "";
-	const path = subtractURI(project.path, project.folder.uri).fsPath;
-
-	return window.createOutputChannel(`${displayName} LSP (${prefix}${path})`, {
-		log: true,
-	});
-};
-
-/**
- * Creates a new Biome LSP logger
- */
-const createLspTraceLogger = (project?: Project): LogOutputChannel => {
-	// If the project is missing, we're creating a logger for the global LSP
-	// session. In this case, we don't have a workspace folder to display in the
-	// logger name, so we just use the display name of the extension.
-	if (!project?.folder) {
-		return window.createOutputChannel(
-			`${displayName} LSP trace (global session)`,
+			`${displayName} LSP (global session) (${activationTimestamp})`,
 			{
 				log: true,
 			},
@@ -339,7 +314,39 @@ const createLspTraceLogger = (project?: Project): LogOutputChannel => {
 	const path = subtractURI(project.path, project.folder.uri).fsPath;
 
 	return window.createOutputChannel(
-		`${displayName} LSP trace (${prefix}${path})`,
+		`${displayName} LSP (${prefix}${path}) (${activationTimestamp})`,
+		{
+			log: true,
+		},
+	);
+};
+
+/**
+ * Creates a new Biome LSP logger
+ */
+const createLspTraceLogger = (project?: Project): LogOutputChannel => {
+	// If the project is missing, we're creating a logger for the global LSP
+	// session. In this case, we don't have a workspace folder to display in the
+	// logger name, so we just use the display name of the extension.
+	if (!project?.folder) {
+		return window.createOutputChannel(
+			`${displayName} LSP trace (global session) (${activationTimestamp})`,
+			{
+				log: true,
+			},
+		);
+	}
+
+	// If the project is present, we're creating a logger for a specific project.
+	// In this case, we display the name of the project and the relative path to
+	// the project root in the logger name. Additionally, when in a multi-root
+	// workspace, we prefix the path with the name of the workspace folder.
+	const prefix =
+		operatingMode === "multi-root" ? `${project.folder.name}::` : "";
+	const path = subtractURI(project.path, project.folder.uri).fsPath;
+
+	return window.createOutputChannel(
+		`${displayName} LSP trace (${prefix}${path}) (${activationTimestamp})`,
 		{
 			log: true,
 		},


### PR DESCRIPTION
### Summary

This PR appends the activation timestamp to all output channel names to mitigate a VS Code issue (https://github.com/microsoft/vscode/issues/204946) where the output contains the logs of previous activations, even when reloading the window.