### PR TITLE
fix: `biome.lsp.bin` detection

### DIFF
--- a/src/binary-finder.ts
+++ b/src/binary-finder.ts
@@ -90,7 +90,7 @@ const vsCodeSettingsStrategy: LocatorStrategy = {
 
 			const resolvedBinPath = Utils.resolvePath(path, bin).toString();
 
-			const biome = Uri.file(resolvedBinPath);
+			const biome = Uri.parse(resolvedBinPath);
 
 			if (await fileExists(biome)) {
 				return biome;


### PR DESCRIPTION
### Summary

When setting an explicit binary using `biome.lsp.bin`, it was ignored.

### Description

Using `Uri.file()` seems to not work reliably for turning paths into a `Uri`. `Uri.parse()` works.

### Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [x] Linux
  - [ ] macOS