### PR TITLE
chore: strict TS checks

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -2,4 +2,4 @@ pre-commit:
   commands:
     check:
       glob: "*.{js,ts,json}"
-      run: biome check --write {staged_files} && git add {staged_files}
+      run: pnpm biome check --write {staged_files} && git add {staged_files}

--- a/src/binary-finder.ts
+++ b/src/binary-finder.ts
@@ -13,28 +13,7 @@ import { downloadBiome, getDownloadedVersion } from "./downloader";
 import { debug, info } from "./logger";
 import { fileExists, hasNodeDependencies } from "./utils";
 
-export type LocatorStrategy = {
-	/**
-	 * Name of the strategy.
-	 */
-	name: string;
-
-	/**
-	 * Finds the `biome` binary using the locator's strategy.
-	 *
-	 * When passing a project, the locator should use the given path as the
-	 * context for finding the binary.
-	 */
-	find: (path?: Uri) => Uri | undefined | Promise<Uri | undefined>;
-};
-
-export type BinaryFinderResult = Promise<
-	| {
-			bin: Uri;
-			strategy: LocatorStrategy;
-	  }
-	| undefined
->;
+export type BinaryFinderResult = Promise<{ bin: Uri } | undefined>;
 
 /**
  * VSCode Settings Strategy
@@ -71,7 +50,7 @@ export type BinaryFinderResult = Promise<
  *
  * General VS Code settings overriding rules apply.
  */
-const vsCodeSettingsStrategy: LocatorStrategy = {
+const vsCodeSettingsStrategy = {
 	name: "VSCode Settings",
 	find: async (path?: Uri): Promise<Uri | undefined> => {
 		const bin = getLspBin(path);
@@ -85,18 +64,18 @@ const vsCodeSettingsStrategy: LocatorStrategy = {
 				debug(
 					"Biome binary path is empty in VS Code settings, skipping",
 				);
-				return undefined;
+				return;
 			}
 
-			const resolvedBinPath = Utils.resolvePath(path, bin).toString();
+			const resolvedBinPath = path
+				? Utils.resolvePath(path, bin).toString()
+				: bin;
 
-			const biome = Uri.file(resolvedBinPath);
+			const biome = Uri.parse(resolvedBinPath);
 
 			if (await fileExists(biome)) {
 				return biome;
 			}
-
-			return undefined;
 		};
 
 		const findPlatformSpecificBinary = async (
@@ -104,16 +83,12 @@ const vsCodeSettingsStrategy: LocatorStrategy = {
 		): Promise<Uri | undefined> => {
 			debug(
 				"Trying to find platform-specific Biome binary in VS Code settings",
-				{
-					bin,
-				},
+				{ bin },
 			);
 
 			if (platformIdentifier in bin) {
-				return findBinary(bin[platformIdentifier]);
+				return await findBinary(bin[platformIdentifier]);
 			}
-
-			return undefined;
 		};
 
 		if (typeof bin === "string") {
@@ -121,10 +96,10 @@ const vsCodeSettingsStrategy: LocatorStrategy = {
 		}
 
 		if (typeof bin === "object" && bin !== null) {
-			return findPlatformSpecificBinary(bin);
+			return await findPlatformSpecificBinary(bin);
 		}
 
-		return undefined;
+		debug("LSP bin not set VS Code settings", { bin });
 	},
 };
 
@@ -149,7 +124,7 @@ const vsCodeSettingsStrategy: LocatorStrategy = {
  * compatibility with various systems such as NixOS, which handle dynamically
  * linked binaries differently.
  */
-const nodeModulesStrategy: LocatorStrategy = {
+const nodeModulesStrategy = {
 	name: "Node Modules",
 	find: async (path: Uri): Promise<Uri | undefined> => {
 		debug("Trying to find Biome binary in Node Modules", {
@@ -174,14 +149,11 @@ const nodeModulesStrategy: LocatorStrategy = {
 				join(binPackage, platformSpecificBinaryName),
 			);
 
-			if (!(await fileExists(binPath))) {
-				return undefined;
+			if (await fileExists(binPath)) {
+				return binPath;
 			}
-
-			return binPath;
 		} catch (error) {
-			debug("Failed to find Biome binary in Node Modules", error);
-			return undefined;
+			debug("Failed to find Biome binary in Node Modules", { error });
 		}
 	},
 };
@@ -193,7 +165,7 @@ const nodeModulesStrategy: LocatorStrategy = {
  * binary from a Yarn Plug'n'Play (PnP) installation by looking for the `biome`
  * binary in the Yarn PnP installation.
  */
-const yarnPnpStrategy: LocatorStrategy = {
+const yarnPnpStrategy = {
 	name: "Yarn Plug'n'Play",
 	find: async (path: Uri): Promise<Uri | undefined> => {
 		debug("Trying to find Biome binary in Yarn Plug'n'Play", {
@@ -242,7 +214,7 @@ const yarnPnpStrategy: LocatorStrategy = {
  * The PATH environment variable is scanned from left to right, and the first
  * `biome` executable found is returned, if any.
  */
-const pathEnvironmentVariableStrategy: LocatorStrategy = {
+const pathEnvironmentVariableStrategy = {
 	name: "Path Environment Variable",
 	find: async (): Promise<Uri | undefined> => {
 		const pathEnv = process.env.PATH;
@@ -270,7 +242,7 @@ const pathEnvironmentVariableStrategy: LocatorStrategy = {
 	},
 };
 
-const downloadBiomeStrategy: LocatorStrategy = {
+const downloadBiomeStrategy = {
 	name: "Download Biome",
 	find: async (): Promise<Uri | undefined> => {
 		debug("Trying to find downloaded Biome binary");
@@ -333,26 +305,20 @@ export const findBiomeLocally = async (
 ): Promise<BinaryFinderResult> => {
 	const binPathInSettings = await vsCodeSettingsStrategy.find(path);
 	if (binPathInSettings) {
-		debug("Found Biome binary in VS Code settings (biome.lsp.bin)", {
+		info("Found Biome binary in VS Code settings (biome.lsp.bin)", {
 			path: binPathInSettings.fsPath,
 		});
 
-		return {
-			bin: binPathInSettings,
-			strategy: vsCodeSettingsStrategy,
-		};
+		return { bin: binPathInSettings };
 	}
 
 	const binPathInNodeModules = await nodeModulesStrategy.find(path);
 	if (binPathInNodeModules) {
-		debug("Found Biome binary in Node Modules", {
+		info("Found Biome binary in Node Modules", {
 			path: binPathInNodeModules.fsPath,
 		});
 
-		return {
-			bin: binPathInNodeModules,
-			strategy: nodeModulesStrategy,
-		};
+		return { bin: binPathInNodeModules };
 	}
 
 	const binPathInYarnPnP = await yarnPnpStrategy.find(path);
@@ -361,10 +327,7 @@ export const findBiomeLocally = async (
 			path: binPathInYarnPnP.fsPath,
 		});
 
-		return {
-			bin: binPathInYarnPnP,
-			strategy: yarnPnpStrategy,
-		};
+		return { bin: binPathInYarnPnP };
 	}
 
 	// Todo: remove this conditional when we remove the deprecated `biome.searchInPath` setting
@@ -375,10 +338,7 @@ export const findBiomeLocally = async (
 			debug("Found Biome binary in PATH environment variable", {
 				path: binPathInPathEnvironmentVariable.fsPath,
 			});
-			return {
-				bin: binPathInPathEnvironmentVariable,
-				strategy: pathEnvironmentVariableStrategy,
-			};
+			return { bin: binPathInPathEnvironmentVariable };
 		}
 	}
 
@@ -392,10 +352,7 @@ export const findBiomeLocally = async (
 			debug("Found downloaded Biome binary", {
 				path: downloadedBinPath.fsPath,
 			});
-			return {
-				bin: downloadedBinPath,
-				strategy: downloadBiomeStrategy,
-			};
+			return { bin: downloadedBinPath };
 		}
 	}
 
@@ -433,10 +390,7 @@ export const findBiomeGlobally = async (): Promise<BinaryFinderResult> => {
 			path: binPathInSettings.fsPath,
 		});
 
-		return {
-			bin: binPathInSettings,
-			strategy: vsCodeSettingsStrategy,
-		};
+		return { bin: binPathInSettings };
 	}
 
 	// Todo: remove this conditional when we remove the deprecated `biome.searchInPath` setting
@@ -448,10 +402,7 @@ export const findBiomeGlobally = async (): Promise<BinaryFinderResult> => {
 				path: binPathInPathEnvironmentVariable.fsPath,
 			});
 
-			return {
-				bin: binPathInPathEnvironmentVariable,
-				strategy: pathEnvironmentVariableStrategy,
-			};
+			return { bin: binPathInPathEnvironmentVariable };
 		}
 	}
 
@@ -461,10 +412,7 @@ export const findBiomeGlobally = async (): Promise<BinaryFinderResult> => {
 			path: downloadedBinPath.fsPath,
 		});
 
-		return {
-			bin: downloadedBinPath,
-			strategy: downloadBiomeStrategy,
-		};
+		return { bin: downloadedBinPath };
 	}
 
 	debug("Could not find Biome globally using any of the strategies");

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,9 @@ export const isEnabledGlobally = (): boolean => {
 	const inspect = workspace
 		.getConfiguration("biome")
 		.inspect<boolean>("enabled");
-	return (inspect.globalValue ?? inspect.defaultValue) === true;
+	return inspect
+		? (inspect.globalValue ?? inspect.defaultValue) === true
+		: false;
 };
 
 /**
@@ -73,26 +75,10 @@ export const getWorkspaceFolderProjectDefinitions = (
  * transparently for users that have not yet migrated to the new setting.
  */
 export const getLspBin = (
-	scope: ConfigurationScope,
+	scope?: ConfigurationScope,
 ): LspBinSetting | undefined => {
-	const lspBin = config<LspBinSetting>("lsp.bin", {
-		default: undefined,
-		scope: scope,
-	});
-
-	const deprecatedLspBin = config<string>("lspBin", {
-		default: undefined,
-		scope: scope,
-	});
-
-	switch (lspBin) {
-		case undefined:
-			return deprecatedLspBin;
-		case null:
-			return deprecatedLspBin;
-		case "":
-			return deprecatedLspBin;
-		default:
-			return lspBin;
-	}
+	return (
+		config<LspBinSetting>("lsp.bin", { scope }) ||
+		config<string>("lspBin", { scope }) // deprecated setting for fallback.
+	);
 };

--- a/src/session.ts
+++ b/src/session.ts
@@ -35,7 +35,7 @@ import {
 export type Session = {
 	bin: Uri;
 	tempBin?: Uri;
-	project: Project;
+	project?: Project;
 	client: LanguageClient;
 };
 
@@ -67,7 +67,7 @@ export const createSession = async (
 	return {
 		bin: findResult.bin,
 		tempBin: tempBin,
-		project: project,
+		project,
 		client: createLanguageClient(tempBin ?? findResult.bin, project),
 	};
 };
@@ -95,7 +95,7 @@ export const destroySession = async (session: Session) => {
 const copyBinaryToTemporaryLocation = async (
 	bin: Uri,
 ): Promise<Uri | undefined> => {
-	// Retrieve the the version of the binary
+	// Retrieve the version of the binary
 	// We call biome with --version which outputs the version in the format
 	// of "Version: 1.0.0"
 	const version = spawnSync(bin.fsPath, ["--version"])
@@ -146,7 +146,7 @@ const copyBinaryToTemporaryLocation = async (
 
 		return location;
 	} catch (error) {
-		return undefined;
+		warn(`Error copying binary: ${error}`);
 	}
 };
 
@@ -164,7 +164,7 @@ export const createGlobalSessionWhenNecessary = async () => {
 			info("Created a global LSP session");
 		} catch (e) {
 			error("Failed to create global LSP session", {
-				error: e.toString(),
+				error: `${e}`,
 			});
 			state.globalSession?.client.dispose();
 			state.globalSession = undefined;
@@ -311,7 +311,7 @@ const createLspLogger = (project?: Project): LogOutputChannel => {
 	// workspace, we prefix the path with the name of the workspace folder.
 	const prefix =
 		operatingMode === "multi-root" ? `${project.folder.name}::` : "";
-	const path = subtractURI(project.path, project.folder.uri).fsPath;
+	const path = subtractURI(project.path, project.folder.uri)?.fsPath;
 
 	return window.createOutputChannel(
 		`${displayName} LSP (${prefix}${path}) (${activationTimestamp})`,
@@ -343,7 +343,7 @@ const createLspTraceLogger = (project?: Project): LogOutputChannel => {
 	// workspace, we prefix the path with the name of the workspace folder.
 	const prefix =
 		operatingMode === "multi-root" ? `${project.folder.name}::` : "";
-	const path = subtractURI(project.path, project.folder.uri).fsPath;
+	const path = subtractURI(project.path, project.folder.uri)?.fsPath;
 
 	return window.createOutputChannel(
 		`${displayName} LSP trace (${prefix}${path}) (${activationTimestamp})`,

--- a/src/state.ts
+++ b/src/state.ts
@@ -13,11 +13,9 @@ export type State = {
 	 */
 	state:
 		| "initializing"
-		| "disabled"
 		| "starting"
 		| "restarting"
 		| "started"
-		| "running"
 		| "stopping"
 		| "stopped"
 		| "error";
@@ -43,7 +41,7 @@ export type State = {
 const _state: State = {
 	state: "initializing",
 	activeProject: undefined,
-	sessions: new Map<Project, Session>([]),
+	sessions: new Map<Project, Session>(),
 	globalSession: undefined,
 	hidden: false,
 } as State;

--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -21,11 +21,7 @@ export const updateStatusBar = () => {
 		return;
 	}
 
-	if (
-		!isEnabled(state.activeProject?.folder) ||
-		state.state === "disabled" ||
-		state.hidden
-	) {
+	if (!isEnabled(state.activeProject?.folder) || state.hidden) {
 		statusBar.item.hide();
 		return;
 	}
@@ -44,29 +40,14 @@ const getBiomeVersion = () => {
 	const session = state.activeProject
 		? state.sessions.get(state.activeProject)
 		: state.globalSession;
-	return session?.client.initializeResult?.serverInfo.version ?? "";
+	return session?.client.initializeResult?.serverInfo?.version ?? "";
 };
 
 const getStateText = (): string => {
-	switch (state.state) {
-		case "initializing":
-			return "Biome";
-		case "starting":
-			return "Biome";
-		case "restarting":
-			return "Biome";
-		case "started":
-			return "Biome";
-		case "stopping":
-			return "Biome";
-		case "stopped":
-			return "Biome";
-		default:
-			return "Biome";
-	}
+	return "Biome";
 };
 
-const getStateTooltip = () => {
+const getStateTooltip = (): string => {
 	switch (state.state) {
 		case "initializing":
 			return "Initializing";
@@ -82,8 +63,6 @@ const getStateTooltip = () => {
 			return "Stopped";
 		case "error":
 			return "Error";
-		default:
-			return "Biome";
 	}
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 		"outDir": "out",
 		"rootDir": "src",
 		"sourceMap": true,
+		"strict": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true
 	},


### PR DESCRIPTION
### Summary

Enables TypeScript `strict` checks and performed a little bit of code cleanups.

### Description

As I was just debugging the VS Code extension, I noticed there were quite a few subtle type issues that made it hard to reason about what was going on.

I also ran into an issue with `ky`, that I was able to resolve by changing from a static import to a dynamic one. It puzzled me slightly because I didn't change anything in the lock file.

### Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [x] Linux
  - [ ] macOS