### PR TITLE
feat: add snippets to supported language identifiers

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -124,6 +124,7 @@ export const supportedLanguageIdentifiers: string[] = [
 	"javascriptreact",
 	"json",
 	"jsonc",
+	"snippets",
 	"svelte",
 	"tailwindcss",
 	"typescript",


### PR DESCRIPTION
### Summary

Add snippets to supported language identifiers

### Description

VS Code snippets are just JSON files, which is supported by Biome.

### Related Issue

This PR closes #555

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [x] Linux
  - [ ] macOS