### PR TITLE
fix: path parsing on windows

### DIFF
--- a/src/binary-finder.ts
+++ b/src/binary-finder.ts
@@ -67,11 +67,7 @@ const vsCodeSettingsStrategy = {
 				return;
 			}
 
-			const resolvedBinPath = path
-				? Utils.resolvePath(path, bin).toString()
-				: bin;
-
-			const biome = Uri.parse(resolvedBinPath);
+			const biome = path ? Utils.resolvePath(path, bin) : Uri.file(bin);
 
 			if (await fileExists(biome)) {
 				return biome;

--- a/src/binary-finder.ts
+++ b/src/binary-finder.ts
@@ -2,7 +2,6 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { delimiter } from "node:path";
 import { Uri, window } from "vscode";
-import { Utils } from "vscode-uri";
 import { config, getLspBin } from "./config";
 import {
 	platformIdentifier,
@@ -67,7 +66,7 @@ const vsCodeSettingsStrategy = {
 				return;
 			}
 
-			const biome = path ? Utils.resolvePath(path, bin) : Uri.file(bin);
+			const biome = Uri.file(bin);
 
 			if (await fileExists(biome)) {
 				return biome;

--- a/src/project.ts
+++ b/src/project.ts
@@ -103,7 +103,7 @@ const getProjectDefinitionForSingleFile = (): ProjectDefinition | undefined => {
 		return;
 	}
 
-	const parentFolderURI = Uri.parse(
+	const parentFolderURI = Uri.file(
 		Utils.resolvePath(singleFileURI, "..").fsPath,
 	);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,7 +94,7 @@ export const subtractURI = (original: Uri, subtract: Uri): Uri | undefined => {
 
 	result = result === "" ? "/" : result;
 
-	return Uri.parse(result);
+	return Uri.file(result);
 };
 
 /**
@@ -242,7 +242,7 @@ export const getPathRelativeToWorkspaceFolder = (
 	folder: WorkspaceFolder,
 	path?: string,
 ): Uri => {
-	return Uri.parse(Utils.joinPath(folder.uri, path ?? "").fsPath);
+	return Uri.file(Utils.joinPath(folder.uri, path ?? "").fsPath);
 };
 
 /**


### PR DESCRIPTION
### Summary

This PR changes the usage of `Uri.parse` by `Uri.file` to fix an issue where paths where incorrectly parsed on Windows, which would result in the extension not creating projects.

### Related Issue

This PR closes #546

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [x] Windows
  - [ ] Linux
  - [x] macOS