### PR TITLE
feat: enable html language

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -120,6 +120,7 @@ export const supportedLanguageIdentifiers: string[] = [
 	"astro",
 	"css",
 	"graphql",
+	"html",
 	"javascript",
 	"javascriptreact",
 	"json",


### PR DESCRIPTION
### Summary

This PR adds support for the `html` language (Biome `>= 2`).

The html formatter still needs to be explicitly enabled in the Biome configuration.

```
  "html": {
    "formatter": {
      "enabled": true
    }
  },
```

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS