### PR TITLE
feat: support `biome.configurationPath` in extension config

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,12 @@
 					"default": false,
 					"scope": "resource"
 				},
+				"biome.configurationPath": {
+					"type": "string",
+					"markdownDescription": "Path to the configuration file to prefer over the default `biome.json`.",
+					"examples": ["/path/to/biome.json"],
+					"scope": "resource"
+				},
 				"biome.projects": {
 					"anyOf": [
 						{


### PR DESCRIPTION
### Summary

Extension config now supports `biome.configurationPath`, defined in `workspace/configuration` request on the Biome LSP server.

### Description

Added a configuration item `biome.configurationPath` to `package.json`.

### Related Issue

This PR closes #513

### Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS