### PR TITLE
feat: add setting to customize rule severity in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,34 @@
 		],
 		"configuration": {
 			"properties": {
+				"biome.customizations": {
+					"type": "array",
+					"default": [],
+					"description": "Customize rule severity levels",
+					"items": {
+						"type": "object",
+						"properties": {
+							"rule": {
+								"type": "string",
+								"description": "Rule name or pattern (* for all rules)"
+							},
+							"severity": {
+								"type": "string",
+								"enum": [
+									"off",
+									"warn",
+									"error"
+								],
+								"description": "Severity level for the rule"
+							}
+						},
+						"required": [
+							"rule",
+							"severity"
+						],
+						"additionalProperties": false
+					}
+				},
 				"biome.enabled": {
 					"type": "boolean",
 					"default": true,
@@ -158,6 +186,7 @@
 	},
 	"dependencies": {
 		"is-wsl": "3.1.0",
+		"picomatch": "^4.0.2",
 		"vscode-languageclient": "9.0.1",
 		"vscode-uri": "3.1.0"
 	},
@@ -169,6 +198,7 @@
 		"@rollup/plugin-json": "6.1.0",
 		"@rollup/plugin-node-resolve": "16.0.1",
 		"@types/node": "22.15.21",
+		"@types/picomatch": "^4.0.0",
 		"@types/vscode": "^1.80.0",
 		"@vscode/vsce": "3.4.2",
 		"esbuild": "0.25.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       is-wsl:
         specifier: 3.1.0
         version: 3.1.0
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.2
       vscode-languageclient:
         specifier: 9.0.1
         version: 9.0.1
@@ -39,6 +42,9 @@ importers:
       '@types/node':
         specifier: 22.15.21
         version: 22.15.21
+      '@types/picomatch':
+        specifier: ^4.0.0
+        version: 4.0.0
       '@types/vscode':
         specifier: ^1.80.0
         version: 1.99.1
@@ -628,6 +634,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/picomatch@4.0.0':
+    resolution: {integrity: sha512-J1Bng+wlyEERWSgJQU1Pi0HObCLVcr994xT/M+1wcl/yNRTGBupsCxthgkdYG+GCOMaQH7iSVUY3LJVBBqG7MQ==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -2691,6 +2700,8 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/picomatch@4.0.0': {}
 
   '@types/resolve@1.20.2': {}
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -124,26 +124,14 @@ export default class Session {
 			},
 			middleware: {
 				handleDiagnostics: (uri, diagnostics, next) => {
-					this.biome.logger.debug(
-						`Received ${diagnostics.length} diagnostics for ${uri.toString()}: ${JSON.stringify(diagnostics)}`,
-					);
-
 					const customizations = config<RuleCustomization[]>("customizations", {
 						default: [],
 						scope: this.folder,
 					});
 
-					this.biome.logger.debug(
-						`loaded ${customizations.length} customizations for diagnostics: ${JSON.stringify(customizations)}`,
-					);
-
 					const modifiedDiagnostics = this.applyRuleCustomizations(
 						diagnostics,
 						customizations,
-					);
-
-					this.biome.logger.debug(
-						`Modified diagnostics: ${JSON.stringify(modifiedDiagnostics)}`,
 					);
 
 					next(uri, modifiedDiagnostics);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"esModuleInterop": true,
 		"module": "commonjs",
 		"target": "es2021",
 		"lib": ["ES2021"],


### PR DESCRIPTION
### Summary

Add a setting that forces rules to report a different severity within VS Code compared to the project's true Biome configuration.

#### Rationale

The official ESLint extension has a [similar setting (`eslint.rules.customizations`)](https://github.com/microsoft/vscode-eslint/blob/bd75b1966caf4991d3b682b245598352d482b05d/README.md?plain=1#L340) and the most notable usage I've seen is in [Joshua Goldberg's create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/b994ec9fe51d9ba687de70f40ecaa89edff8b0c6/.vscode/settings.json#L7). This allows "mapping" lint errors in VS Code to a different "squiggly line color" than type errors (as mentioned in [this tweet](https://x.com/JoshuaKGoldberg/status/1640013829768638472)).

This might seem like an odd feature or something that [could be addressed by changing the Biome configuration](https://github.com/biomejs/biome-vscode/discussions/84#discussioncomment-9359659). However, it has been mentioned in other discussions (such as [here](https://github.com/biomejs/biome/discussions/3106#discussioncomment-11942326)).

Personally, after integrating this into my workflow for ESLint, I really appreciate being able to distinguish at first glance whether something is a lint error or a type error. I frequently work on projects where I can't change the Biome configuration, or would need to customize the config while ensuring I don't commit those changes, which isn't sustainable. Additionally, it might [not achieve the desired outcome](https://github.com/biomejs/biome/discussions/3106#discussioncomment-12659211) of setting the severity of all configured rules (or a subset) to a specific severity level.

### Description

This PR includes an initial prototype demonstrating how this feature could be implemented. I'm willing to invest further effort in developing it, though I have limited experience with both VSCode extension development and Rust, so I might need guidance or pointers in the right direction. After testing this implementation for several days and spending time in the debugger, I have some initial questions:

- The `diagnostic.code` in `Session.matchesRule` is typically the rule name, but I've also encountered codes like `'parse'` when Biome finds a syntax error while parsing a file. Since the severity of such diagnostics shouldn't be remapped, how can we distinguish between diagnostics where severity remapping is allowed versus those where it isn't? Should we define a limited set to ignore? Should users only be able to configure individual rules and a `'*'` wildcard for all rules?
- Would you consider adding a dependency like [picomatch](https://github.com/micromatch/picomatch/tree/master) to the project, or should we implement custom matching logic?
- Is there a more effective approach than implementing this as middleware?
- Do you have suggestions regarding configuration (e.g., setting scope, format of settings, which severity to include)?

### Related Issue

This PR closes no open issue that I know of.

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS