### PR TITLE
fix: remove unsupported `compact` trace mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
 					"enum": [
 						"off",
 						"messages",
-						"compact",
 						"verbose"
 					],
 					"description": "Sets the tracing level for communication between the extension and the Biome Language Server.",


### PR DESCRIPTION
### Summary

Removes the unsupported `compact` trace mode.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #665