### PR TITLE
Remove `"here"` debug log statement when active text editor changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,7 +172,6 @@ export default class Extension {
 
 		// Register a callback to update the status bar when the active text editor changes
 		window.onDidChangeActiveTextEditor(() => {
-			console.log("here");
 			this.statusBar.update();
 		});
 


### PR DESCRIPTION
I've seen this pop up in the debug output in VSCode and at first assumed it was in our extension and, in fact, assumed that it was me who added it (since I love logging "here"), but turns out it's biome-vscode that logs it.
