### PR TITLE
fix: only start one global instance

### DIFF
--- a/.changeset/ripe-ads-jump.md
+++ b/.changeset/ripe-ads-jump.md
@@ -1,0 +1,5 @@
+---
+"biome": patch
+---
+
+Ensure only one global LSP session is created

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,6 +192,7 @@ export default class Extension {
 
 		for (const [_folder, biome] of this.biomes) {
 			await biome.stop();
+			this.biomes.delete(_folder);
 		}
 
 		this.logger.info("⏹️ Biome extension stopped.");
@@ -293,12 +294,11 @@ export default class Extension {
 		const createGlobalInstanceIfNotExists = async () => {
 			if (!this.biomes.get("global")) {
 				this.biomes.set("global", Biome.createGlobalInstance(this));
-				this.biomes.get("global")?.start();
 			}
 		};
 
 		const createGlobalInstanceIfNeeded = async (
-			editor: TextEditor | undefined,
+			editor?: TextEditor | undefined,
 		) => {
 			this.logger.debug(editor?.document?.uri.toString());
 
@@ -341,7 +341,10 @@ export default class Extension {
 
 		// Register the listener for when the active text editor changes
 		window.onDidChangeActiveTextEditor(
-			debounce(createGlobalInstanceIfNeeded, 0),
+			debounce(async () => {
+				await createGlobalInstanceIfNeeded();
+				await this.biomes.get("global")?.start();
+			}, 0),
 		);
 	}
 


### PR DESCRIPTION
### Summary

This PR fixes an issue where we would start multiple global instances when opening VS Code while the last active text editor was the VS Code settings.json file.

### Related Issue

n/a

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS