### PR TITLE
fix: absolute path handling in `biome.lsp.bin`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,7 +76,7 @@ export const getLspBin = (
 		}) || config<string>("lspBin", { scope: workspaceFolder }); // deprecated setting for fallback.
 
 	const resolvePath = (lspBin: string, workspaceFolder?: WorkspaceFolder) => {
-		// If the specified path is relative, resolve it againt the root of
+		// If the specified path is relative, resolve it against the root of
 		// the workspace folder (if any).
 		if (workspaceFolder && !isAbsolute(lspBin)) {
 			return Uri.file(Utils.resolvePath(workspaceFolder.uri, lspBin).fsPath);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { extname, isAbsolute } from "node:path";
 import {
 	type ConfigurationScope,
 	FileType,
@@ -75,9 +76,13 @@ export const getLspBin = (
 		}) || config<string>("lspBin", { scope: workspaceFolder }); // deprecated setting for fallback.
 
 	const resolvePath = (lspBin: string, workspaceFolder?: WorkspaceFolder) => {
-		return workspaceFolder
-			? Uri.file(Utils.resolvePath(workspaceFolder.uri, lspBin).fsPath)
-			: Uri.file(lspBin);
+		// If the specified path is relative, resolve it againt the root of
+		// the workspace folder (if any).
+		if (workspaceFolder && !isAbsolute(lspBin)) {
+			return Uri.file(Utils.resolvePath(workspaceFolder.uri, lspBin).fsPath);
+		}
+
+		return Uri.file(lspBin);
 	};
 
 	if (typeof lspBin === "string") {
@@ -114,12 +119,18 @@ export const debounce = <TArgs extends unknown[]>(
 
 export const safeSpawnSync = (
 	command: string,
-	args?: readonly string[],
+	args: readonly string[] = [],
 ): string | undefined => {
 	let output: string | undefined;
 
+	// If the command is a powershell script, run it through powershell
+	if (extname(command) === ".ps1") {
+		args = [command, ...args];
+		command = "powershell.exe";
+	}
+
 	try {
-		const result = spawnSync(command, args ?? [], { encoding: "utf8" });
+		const result = spawnSync(command, args, { encoding: "utf8" });
 
 		if (result.error || result.status !== 0) {
 			output = undefined;


### PR DESCRIPTION
### Summary

This PR fixes the handling of absolute paths in the `biome.lsp.bin` setting.

On Windows, this could lead to broken paths.

Now we'll check the path to determine whether an absolute path or a relative path was provided. If the path is absolute, it's taken as-is and if it's relative we'll resolve it against the root of the workspace folder.

### Related Issue

n/a
### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [x] Windows
  - [ ] Linux
  - [x] macOS