### PR TITLE
fix: only start global session once

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,7 +110,8 @@ export default class Extension {
 	 * Creates the extension from the context
 	 */
 	public static create(context: ExtensionContext): Extension {
-		return Extension.instance ?? new Extension(context);
+		Extension.instance ??= new Extension(context);
+		return Extension.instance;
 	}
 
 	/**
@@ -293,7 +294,10 @@ export default class Extension {
 	private async createGlobalInstance(): Promise<void> {
 		const createGlobalInstanceIfNotExists = async () => {
 			if (!this.biomes.get("global")) {
-				this.biomes.set("global", Biome.createGlobalInstance(this));
+				const biome = Biome.createGlobalInstance(this);
+				biome.start();
+
+				this.biomes.set("global", biome);
 			}
 		};
 
@@ -343,8 +347,7 @@ export default class Extension {
 		window.onDidChangeActiveTextEditor(
 			debounce(async (editor?: TextEditor) => {
 				await createGlobalInstanceIfNeeded(editor);
-				await this.biomes.get("global")?.start();
-			}, 0),
+			}, 10),
 		);
 	}
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -73,14 +73,6 @@ export default class Session {
 	}
 
 	/**
-	 * Restarts the LSP session.
-	 */
-	public async restart() {
-		await this.stop();
-		await this.start();
-	}
-
-	/**
 	 * Creates a new language client for the session.
 	 */
 	private createLanguageClient(): LanguageClient {


### PR DESCRIPTION
### Summary

The Biome process for the global session is now started only once.

I also happened to notice that the extension's singleton is not actually a singleton. I don't know if that caused any actual issues, but I fixed it to be on the safe side.

### Related Issue

This PR closes #743.

### Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [x] Linux
  - [ ] macOS