### PR TITLE
feat: add tree-sitter-based token provider for GritQL

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,20 @@
 			"sourceMapRenames": true
 		},
 		{
+			"name": "🧩 Debug GritQL Token Provider",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentKind=node",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}/test/fixtures/gritql"
+			],
+			"outFiles": ["${workspaceFolder}/out/**/*.js"],
+			"preLaunchTask": "npm: dev",
+			"sourceMapRenames": true
+		},
+		{
 			"name": "🧩 Debug Extension (single-root workspace)",
 			"type": "extensionHost",
 			"request": "launch",

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,5 +2,6 @@
 !resources
 !LICENSE*
 !out/main.js
+!out/*.wasm
 !package.json
 !README.md

--- a/package.json
+++ b/package.json
@@ -138,6 +138,12 @@
 				"extensions": [
 					".rast"
 				]
+			},
+			{
+				"id": "gritql",
+				"extensions": [
+					".grit"
+				]
 			}
 		],
 		"grammars": [
@@ -157,8 +163,10 @@
 	},
 	"dependencies": {
 		"is-wsl": "3.1.0",
+		"tree-sitter-gritql": "0.1.1",
 		"vscode-languageclient": "9.0.1",
-		"vscode-uri": "3.1.0"
+		"vscode-uri": "3.1.0",
+		"web-tree-sitter": "0.25.10"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.6",
@@ -174,6 +182,7 @@
 		"lefthook": "1.13.6",
 		"ovsx": "0.10.6",
 		"rollup": "4.52.4",
+		"rollup-plugin-copy": "^3.5.0",
 		"rollup-plugin-esbuild": "6.2.1",
 		"typescript": "5.9.3"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       is-wsl:
         specifier: 3.1.0
         version: 3.1.0
+      tree-sitter-gritql:
+        specifier: 0.1.1
+        version: 0.1.1(tree-sitter@0.25.0)
       vscode-languageclient:
         specifier: 9.0.1
         version: 9.0.1
       vscode-uri:
         specifier: 3.1.0
         version: 3.1.0
+      web-tree-sitter:
+        specifier: 0.25.10
+        version: 0.25.10
     devDependencies:
       '@biomejs/biome':
         specifier: 2.2.6
@@ -57,6 +63,9 @@ importers:
       rollup:
         specifier: 4.52.4
         version: 4.52.4
+      rollup-plugin-copy:
+        specifier: ^3.5.0
+        version: 3.5.0
       rollup-plugin-esbuild:
         specifier: 6.2.1
         version: 6.2.1(esbuild@0.25.11)(rollup@4.52.4)
@@ -750,6 +759,16 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/fs-extra@8.1.5':
+    resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
+
+  '@types/glob@7.2.0':
+    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
+
+  '@types/minimatch@6.0.0':
+    resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
+    deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -968,6 +987,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -1229,6 +1251,9 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1260,9 +1285,17 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  globby@10.0.1:
+    resolution: {integrity: sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==}
+    engines: {node: '>=8'}
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -1340,6 +1373,10 @@ packages:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1386,6 +1423,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-object@3.0.1:
+    resolution: {integrity: sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==}
+    engines: {node: '>=0.10.0'}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -1640,6 +1681,13 @@ packages:
   node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-addon-api@8.5.0:
+    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -1648,6 +1696,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-sarif-builder@3.2.0:
     resolution: {integrity: sha512-kVIOdynrF2CRodHZeP/97Rh1syTUHBNiw17hUCIVhlhEsWlfJm19MuO56s4MdKbr22xWx6mzMnNAgXzVlIYM9Q==}
@@ -1732,6 +1784,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1849,6 +1905,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup-plugin-copy@3.5.0:
+    resolution: {integrity: sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==}
+    engines: {node: '>=8.3'}
 
   rollup-plugin-esbuild@6.2.1:
     resolution: {integrity: sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA==}
@@ -2039,6 +2099,18 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tree-sitter-gritql@0.1.1:
+    resolution: {integrity: sha512-IN+w/kSUJykJFSimPlxNk/4nj/uKrZ4r2vV6/8KrbUcs249qlUiNk/qwODEgwS6Yf+0wcws7EUDsprCbkXb/dw==}
+    peerDependencies:
+      tree-sitter: ^0.21.0
+      tree_sitter: '*'
+    peerDependenciesMeta:
+      tree_sitter:
+        optional: true
+
+  tree-sitter@0.25.0:
+    resolution: {integrity: sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2127,6 +2199,14 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  web-tree-sitter@0.25.10:
+    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
+    peerDependencies:
+      '@types/emscripten': ^1.40.0
+    peerDependenciesMeta:
+      '@types/emscripten':
+        optional: true
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -2898,6 +2978,19 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/fs-extra@8.1.5':
+    dependencies:
+      '@types/node': 22.18.12
+
+  '@types/glob@7.2.0':
+    dependencies:
+      '@types/minimatch': 6.0.0
+      '@types/node': 22.18.12
+
+  '@types/minimatch@6.0.0':
+    dependencies:
+      minimatch: 10.0.1
+
   '@types/node@12.20.55': {}
 
   '@types/node@22.18.12':
@@ -3144,6 +3237,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorette@1.4.0: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -3409,6 +3504,8 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -3452,10 +3549,30 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+
+  globby@10.0.1:
+    dependencies:
+      '@types/glob': 7.2.0
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      glob: 7.2.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
 
   globby@11.1.0:
     dependencies:
@@ -3539,8 +3656,12 @@ snapshots:
 
   index-to-position@1.2.0: {}
 
-  inherits@2.0.4:
-    optional: true
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
 
   ini@1.3.8:
     optional: true
@@ -3575,6 +3696,8 @@ snapshots:
   is-module@1.0.0: {}
 
   is-number@7.0.0: {}
+
+  is-plain-object@3.0.1: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -3812,9 +3935,15 @@ snapshots:
   node-addon-api@4.3.0:
     optional: true
 
+  node-addon-api@7.1.1: {}
+
+  node-addon-api@8.5.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4: {}
 
   node-sarif-builder@3.2.0:
     dependencies:
@@ -3838,7 +3967,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
 
   open@10.1.2:
     dependencies:
@@ -3911,6 +4039,8 @@ snapshots:
       entities: 6.0.0
 
   path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -4031,6 +4161,14 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rollup-plugin-copy@3.5.0:
+    dependencies:
+      '@types/fs-extra': 8.1.5
+      colorette: 1.4.0
+      fs-extra: 8.1.0
+      globby: 10.0.1
+      is-plain-object: 3.0.1
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.25.11)(rollup@4.52.4):
     dependencies:
@@ -4269,6 +4407,17 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tree-sitter-gritql@0.1.1(tree-sitter@0.25.0):
+    dependencies:
+      node-addon-api: 7.1.1
+      node-gyp-build: 4.8.4
+      tree-sitter: 0.25.0
+
+  tree-sitter@0.25.0:
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+
   tslib@2.8.1: {}
 
   tunnel-agent@0.6.0:
@@ -4340,6 +4489,8 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  web-tree-sitter@0.25.10: {}
+
   webidl-conversions@3.0.1: {}
 
   whatwg-encoding@3.1.1:
@@ -4369,8 +4520,7 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
-  wrappy@1.0.2:
-    optional: true
+  wrappy@1.0.2: {}
 
   xml2js@0.5.0:
     dependencies:

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -2,6 +2,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import { defineConfig } from "rollup";
+import copy from "rollup-plugin-copy";
 import esbuild from "rollup-plugin-esbuild";
 
 export default defineConfig([
@@ -19,6 +20,15 @@ export default defineConfig([
 			esbuild({
 				target: "node16",
 				sourceMap: true,
+			}),
+			copy({
+				targets: [
+					{ src: "node_modules/web-tree-sitter/tree-sitter.wasm", dest: "out" },
+					{
+						src: "node_modules/tree-sitter-gritql/tree-sitter-gritql.wasm",
+						dest: "out",
+					},
+				],
 			}),
 		],
 		external: ["vscode", "node:events"],

--- a/src/gritql.ts
+++ b/src/gritql.ts
@@ -1,0 +1,154 @@
+import type {
+	CancellationToken,
+	ExtensionContext,
+	SemanticTokens,
+	TextDocument,
+} from "vscode";
+import {
+	languages,
+	SemanticTokensBuilder,
+	SemanticTokensLegend,
+	window,
+} from "vscode";
+import type {
+	Language as LanguageType,
+	Node,
+	Parser as ParserType,
+} from "web-tree-sitter";
+import { Language, Parser } from "web-tree-sitter";
+import { mapNodeTypeToSemanticType } from "./node_to_token";
+
+const outputChannel = window.createOutputChannel("GritQL Token Provider");
+let gritqlLanguage: LanguageType | null = null;
+
+// Selected semantic tokens for GritQL
+// https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
+const tokenTypes: Map<string, number> = new Map([
+	["variable", 0],
+	["string", 1],
+	["number", 2],
+	["keyword", 3],
+	["comment", 4],
+	["function", 5],
+	["parameter", 6],
+	["operator", 7],
+	["regexp", 8],
+]);
+const legend = new SemanticTokensLegend(Array.from(tokenTypes.keys()));
+
+interface IParsedToken {
+	line: number;
+	startCharacter: number;
+	length: number;
+	tokenType: string;
+}
+
+async function initializeTreeSitter(context: ExtensionContext): Promise<void> {
+	try {
+		await Parser.init();
+		gritqlLanguage = await Language.load(
+			`${context.extensionPath}/out/tree-sitter-gritql.wasm`,
+		);
+		outputChannel.appendLine("Successfully loaded GritQL tree-sitter language");
+	} catch (error) {
+		outputChannel.appendLine(`Failed to load GritQL tree-sitter: ${error}`);
+		throw error;
+	}
+}
+
+class DocumentSemanticTokensProvider implements DocumentSemanticTokensProvider {
+	private parser: ParserType;
+	constructor() {
+		// Initialize parser synchronously - tree-sitter should be ready by now
+		this.parser = new Parser();
+		if (gritqlLanguage) {
+			this.parser.setLanguage(gritqlLanguage);
+		}
+	}
+
+	async provideDocumentSemanticTokens(
+		document: TextDocument,
+		_token: CancellationToken,
+	): Promise<SemanticTokens> {
+		// Parse document with tree-sitter
+		const tree = this.parser.parse(document.getText());
+		if (!tree) {
+			return new SemanticTokensBuilder(legend).build();
+		}
+		// Convert syntax tree to semantic tokens
+		const tokens = this._extractTokensFromTree(
+			tree.rootNode,
+			document.getText(),
+		);
+
+		// Build semantic tokens
+		const builder = new SemanticTokensBuilder(legend);
+		tokens.forEach((token) => {
+			builder.push(
+				token.line,
+				token.startCharacter,
+				token.length,
+				this._encodeTokenType(token.tokenType),
+			);
+		});
+
+		return builder.build();
+	}
+
+	private _extractTokensFromTree(
+		node: Node,
+		sourceText: string,
+	): IParsedToken[] {
+		const tokens: IParsedToken[] = [];
+		this._walkTree(node, sourceText, tokens);
+		return tokens;
+	}
+
+	private _walkTree(
+		node: Node,
+		sourceText: string,
+		tokens: IParsedToken[],
+	): void {
+		if (node.type === "ERROR") {
+			return;
+		}
+
+		// Map tree-sitter node types to semantic token types
+		const tokenType = mapNodeTypeToSemanticType(node.type);
+
+		// If this node should be tokenized and has no children (leaf node)
+		if (tokenType && node.childCount === 0) {
+			const startPos = node.startPosition;
+			const endPos = node.endPosition;
+
+			tokens.push({
+				line: startPos.row,
+				startCharacter: startPos.column,
+				length: endPos.column - startPos.column,
+				tokenType: tokenType,
+			});
+		}
+		// Recursively process children
+		node.children.forEach((child) => {
+			child && this._walkTree(child, sourceText, tokens);
+		});
+	}
+
+	private _encodeTokenType(tokenType: string): number {
+		const index = tokenTypes.get(tokenType);
+		return index !== undefined ? index : 0; // Default to 'variable' if not found
+	}
+}
+
+async function init(context: ExtensionContext): Promise<void> {
+	await initializeTreeSitter(context);
+	context.subscriptions.push(
+		languages.registerDocumentSemanticTokensProvider(
+			{ language: "gritql" },
+			new DocumentSemanticTokensProvider(),
+			legend,
+		),
+	);
+}
+
+export default { init };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "vscode";
 import Extension from "./extension";
+import GritQL from "./gritql";
 
 let extension: Extension | undefined;
 
@@ -9,6 +10,7 @@ let extension: Extension | undefined;
 export const activate = async (context: ExtensionContext) => {
 	extension = Extension.create(context);
 	await extension.init();
+	GritQL.init(context);
 };
 
 /**

--- a/src/node_to_token.ts
+++ b/src/node_to_token.ts
@@ -1,0 +1,112 @@
+// The mapping here is canonical to the mapping between tree-sitter nodes to captures
+// in https://github.com/biomejs/biome-zed/blob/main/languages/grit/highlights.scm
+export function mapNodeTypeToSemanticType(nodeType: string): string | null {
+	// Map GritQL tree-sitter node types to VS Code semantic token types
+	switch (nodeType) {
+		// Variables - from @variable rule
+		case "variable":
+		case "underscore":
+		case "languageName":
+			return "variable";
+
+		// Strings - from @string rule
+		case "codeSnippet":
+		case "doubleQuoteSnippet":
+			return "string";
+
+		// Numbers - from @number rule
+		case "intConstant":
+		case "signedIntConstant":
+		case "doubleConstant":
+			return "number";
+
+		// Boolean - from @boolean rule
+		case "booleanConstant":
+			return "keyword"; // VS Code doesn't have boolean type, use keyword
+
+		// Comments - from @comment rule
+		case "comment":
+			return "comment";
+
+		// Functions - from @function rule (predicateCall, nodeLike, name)
+		case "predicateCall":
+		case "nodeLike":
+		case "name":
+			return "function";
+
+		// Attributes - from @attribute rule
+		case "namedArg":
+			return "parameter"; // VS Code equivalent of attribute
+
+		// Keywords - from @keyword rule (comprehensive list)
+		case "bubble":
+		case "sequential":
+		case "multifile":
+		case "and":
+		case "any":
+		case "not":
+		case "maybe":
+		case "contains":
+		case "until":
+		case "as":
+		case "within":
+		case "after":
+		case "before":
+		case "some":
+		case "every":
+		case "limit":
+		case "includes":
+		case "like":
+		case "private":
+		case "if":
+		case "else":
+		case "where":
+		case "or":
+		case "orelse":
+		case "return":
+			return "keyword";
+
+		// Operators - from @operator rule
+		case "*":
+		case "/":
+		case "%":
+		case "+":
+		case "-":
+		case "!":
+		case "=":
+		case "+=":
+		case ">":
+		case "<":
+		case ">=":
+		case "<=":
+		case "!=":
+		case "==":
+		case "<:":
+			return "operator";
+
+		// Regular expressions - from @string.regex rule
+		case "regex":
+		case "snippetRegex":
+			return "regexp";
+
+		// Punctuation delimiters - map to operator for VS Code
+		case ";":
+		case ".":
+		case ",":
+		case ":":
+			return "operator";
+
+		// Punctuation brackets - VS Code doesn't have bracket type, skip
+		case "(":
+		case ")":
+		case "[":
+		case "]":
+		case "{":
+		case "}":
+			return null; // Let VS Code handle bracket highlighting
+
+		default:
+			// Don't tokenize unknown node types
+			return null;
+	}
+}

--- a/test/fixtures/gritql/test.grit
+++ b/test/fixtures/gritql/test.grit
@@ -1,0 +1,10 @@
+predicate program_contains_logger() {
+  $program <: contains `logger`
+}
+`console.log` => `logger.info` where {
+  program_contains_logger()
+}
+`console.log($message)` where {
+    $name = "Lucy",
+    $message <: r`"([a-zA-Z]*), Lucy"`($greeting) => `$name, $greeting`
+}


### PR DESCRIPTION
### Summary

This PR re-applies the reverted PR #795 created by @daivinhtran , along with a fix for bundling the `.wasm` files into the extension's `.vsix`.

- Copies `tree-sitter.wasm` and `tree-sitter-gritql.wasm` to `out` folder on build
- Allows `.wasm` files into final bundle
- Updates paths

### Tests

- [x] The bundled extension should contain the .wasm files
- [x] The extension should start correctly
- [x] `.grit` files should have syntax highlighting
