### PR TITLE
fix: unable to detect global biome on windows

### DIFF
--- a/src/locator.ts
+++ b/src/locator.ts
@@ -425,8 +425,10 @@ export default class Locator {
 			return;
 		}
 
+		const executable = `biome${process.platform === "win32" ? ".cmd" : ""}`;
+
 		for (const dir of path.split(delimiter)) {
-			const biome = Uri.joinPath(Uri.file(dir), platformSpecificBinaryName);
+			const biome = Uri.joinPath(Uri.file(dir), executable);
 			if (await fileExists(biome)) {
 				this.biome.logger.debug(
 					`🔍 Found Biome binary at "${biome.fsPath}" in PATH`,


### PR DESCRIPTION
### Summary

The executable under `C:\Users\XXXX\AppData\Roaming\npm` is called `biome.cmd`, currently the plugin still tries to find `biome.exe.

### Description

Change `exe` to `cmd` in PATH detection on Windows

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

closes #838

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [X] Windows
  - [ ] Linux
  - [ ] macOS