### PR TITLE
fix: Unable to find the global Biome binary on Windows.

### DIFF
--- a/src/locator.ts
+++ b/src/locator.ts
@@ -26,8 +26,12 @@ import {
 
 export default class Locator {
 	private get globalNodeModulesPaths(): Record<string, Uri | undefined> {
-		const npmGlobalNodeModulesPath = safeSpawnSync("npm", ["root", "-g"]);
-		const pnpmGlobalNodeModulesPath = safeSpawnSync("pnpm", ["root", "-g"]);
+		const npmGlobalNodeModulesPath = safeSpawnSync("npm", ["root", "-g"], {
+			shell: true,
+		});
+		const pnpmGlobalNodeModulesPath = safeSpawnSync("pnpm", ["root", "-g"], {
+			shell: true,
+		});
 		const bunGlobalNodeModulesPath = Utils.resolvePath(
 			Uri.file(homedir()),
 			".bun/install/global/node_modules",


### PR DESCRIPTION
### Summary

<!-- Provide a general summary of your changes -->
When searching for the path of `npm` global packages, add `shell: true` parameters to accommodate dynamic versioning tools such as `fnm`.

### Description

<!-- Describe your changes in detail -->
When using fnm to manage node versions, it is necessary to configure the shell’s profile file to execute the `fnm env` command; only in this way can commands such as `node` be recognized within the shell. 

During my debugging efforts, I noticed the following:

- Executing the command `spawnSync("npm", ["root","-g"],{encoding: "utf8"})` resulted in the error “Error: spawnSync npm ENOENT”. 
- However, when executing the same command with the additional parameter `shell:true`, the correct path was displayed as expected.

I think this might be related to the dynamic management of node versions by `fnm`.

I haven’t tested it on `Linux` and `Mac`, but theoretically, adding the parameter `shell:true` should not affect the normal functioning of these two platforms.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #838 #840 

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [x] I have tested my changes on the following platforms:
  - [x] Windows
  - [ ] Linux
  - [ ] macOS