### PR TITLE
refactor(grit) rename gritql language ID to grit

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 				]
 			},
 			{
-				"id": "gritql",
+				"id": "grit",
 				"extensions": [
 					".grit"
 				]

--- a/src/gritql.ts
+++ b/src/gritql.ts
@@ -144,7 +144,7 @@ async function init(context: ExtensionContext): Promise<void> {
 	await initializeTreeSitter(context);
 	context.subscriptions.push(
 		languages.registerDocumentSemanticTokensProvider(
-			{ language: "gritql" },
+			{ language: "grit" },
 			new DocumentSemanticTokensProvider(),
 			legend,
 		),


### PR DESCRIPTION
### Summary

Rename the `gritql` language ID to `grit`

### Description

The official [Grit](https://marketplace.visualstudio.com/items?itemName=Grit.grit-vscode) extension registers the `grit` language ID. The Biome extension only recently registered the `gritql` language ID for the same file pattern. This is a conflict. For consistency within the VSCode ecosystem, it’s best to stick with one common language ID.

### Related Issue

N/A

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [x] Linux
  - [ ] macOS