### PR TITLE
Expand README with Biome features and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,17 @@ languages:
 In order to use Biome, you must install it, either on a per project basis
 or globally on your machine.
 
+### As dependency
+
 To add Biome to your project, use the package manager specified in your project.
 This will ensure it is listed as a dev-dependency in `package.json`. Then
 configure Biome. Follow the full instructions on the
+[Getting Started](<https://biomejs.dev/guides/getting-started/>) page.
+
+### As stand-alone
+
+If your code editor does not have a Biome Plugin or you intend to use Biome in
+shell scripts, follow the manual installation guide mentioned on the
 [Getting Started](<https://biomejs.dev/guides/getting-started/>) page.
 
 ## Availability


### PR DESCRIPTION
Added detailed description of Biome's features, installation, and language support.

### Summary

The README is lacking important context for users who find BIOME through the VSCode marketplace. How is anyone supposed to know what BIOME is when you hide behind such abstract obfuscated words?

### Description

Added the all-important definition of what BIOME is and does for the user. Your page is entirely missing any mention of its core functionality as a formatter and linter. This is important to users.

Added proper usage instructions that explain how to make the plugin do anything. Also told users when to use a per-project installation vs when to use a global installation (or...did I? I might have forgotten to include this).

Changed the "Installation" section to "Availability". It's more accurate.

### Related Issue

https://github.com/biomejs/website/issues/3490

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [x] Windows
  - [ ] Linux
  - [ ] macOS