### PR TITLE
fix: correctly resolve global modules when npm is missing/unconfigured

### DIFF
--- a/src/locator.ts
+++ b/src/locator.ts
@@ -350,7 +350,7 @@ export default class Locator {
 				this.biome.logger.warn(
 					`🔍 Could not find global Node Modules path for ${key}`,
 				);
-				return;
+				continue;
 			}
 
 			const biome = await this.findBiomeInNodeModules(path);


### PR DESCRIPTION
## Summary
This fixes a bug where `biome-vscode` would fail to use a globally installed `biome` binary (via pnpm or bun) if `npm`'s global configuration was missing or broken.

## The Bug
The `findBiomeInGlobalNodeModules` method iterates over known package managers. However, if looking up the global path for one (e.g., `npm`) failed or returned `undefined`, the code incorrectly performed an early `return`, stopping it from checking subsequent package managers (like `pnpm`).

https://github.com/biomejs/biome-vscode/blob/ff10d68a1907a994ae11c1492491e82130415fd6/src/locator.ts#L344-L364

## The Fix
Replaced the `return` statement with `continue` inside the loop. This ensures that if one package manager resolution fails, the extension proceeds to check the others.

## Impact
Users who install Biome globally via `pnpm` will now be able to use the extension correctly even if they don't use `npm` globally.

## Related Issues
Fixes #944
