### PR TITLE
feat: automatically trust `biomejs.dev` for json schema downloads

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -381,9 +381,9 @@ export default class Extension {
 	 */
 	private async trustBiomeDomain(): Promise<void> {
 		// If we've already attempted to trust the domain, don't do it again
-		// if (this.context.globalState.get("alreadyTrustedBiomeDomain")) {
-		// 	return;
-		// }
+		if (this.context.globalState.get("alreadyTrustedBiomeDomain")) {
+			return;
+		}
 
 		// Get the current list of trusted domains from the configuration
 		const currentlyTrustedDomains = workspace


### PR DESCRIPTION
### Summary

Automatically trust the `biomejs.dev` domain for JSON schema downloads.

### Description

VS Code recently introduced a `json.schemaDownload.trustedDomains` setting that restricts the domains from which JSON schemas can be downloaded.

This PR adds logic for automatically adding `htts://biomejs.dev` to the list of trusted domains for JSON schema downloads.

The extension will only attempt to add the domain once, and save a flag in state so that we don't repeatedly attempt to add it, giving the end user the possibility to remove the trusted domain if they so wish.

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS