### PR TITLE
fix: resolve biome.cmd shim in PATH on Windows & fix global module resolution

### DIFF
--- a/.changeset/win32-pnpm-path-fix.md
+++ b/.changeset/win32-pnpm-path-fix.md
@@ -1,0 +1,5 @@
+---
+"biome": patch
+---
+
+fix: resolve `biome.cmd` shim in `PATH` on Windows & fix global module resolution for `pnpm`

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -350,7 +350,7 @@ export default class Locator {
 				this.biome.logger.warn(
 					`🔍 Could not find global Node Modules path for ${key}`,
 				);
-				return;
+				continue;
 			}
 
 			const biome = await this.findBiomeInNodeModules(path);

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -433,6 +433,16 @@ export default class Locator {
 				);
 				return biome;
 			}
+
+			if (process.platform === "win32") {
+				const biomeCmd = Uri.joinPath(Uri.file(dir), "biome.cmd");
+				if (await fileExists(biomeCmd)) {
+					this.biome.logger.debug(
+						`🔍 Found Biome binary at "${biomeCmd.fsPath}" in PATH`,
+					);
+					return biomeCmd;
+				}
+			}
 		}
 
 		return undefined;


### PR DESCRIPTION
## Summary
This fixes two critical bugs preventing `biome-vscode` from finding global installations:
1. A logic error where missing `npm` configuration prevented checking other package managers (like `pnpm`).
2. A Windows-specific issue where the fallback PATH search only looked for `biome.exe`, missing the `biome.cmd` shim used by package managers.

## The Bug
1. **Global Module Resolution:** The `findBiomeInGlobalNodeModules` method incorrectly used an early `return` if a package manager's path lookup failed, stopping checks for subsequent managers.
2. **Windows PATH Resolution:** When falling back to the system `PATH`, the extension only checked for `platformSpecificBinaryName` (`biome.exe` on Windows). However, global packages installed via `npm` or `pnpm` on Windows typically expose a `biome.cmd` shim and a shell script, not the direct executable, causing the lookup to fail even when `biome` was correctly in the user's PATH.

## The Fix
1. Replaced the `return` statement with `continue` inside the package manager loop.
2. Added a specific check for `biome.cmd` when searching the `PATH` on Windows.

## Impact
Users installing Biome globally on Windows (especially via `pnpm` or `npm`) will now be correctly detected via the `PATH` fallback, and users of alternative package managers will usually be detected by the improved module resolution.

## Related Issues
Fixes #944
