### PR TITLE
fix: copy `web-tree-sitter.wasm` into `out`

### DIFF
--- a/.changeset/cuddly-shrimps-ask.md
+++ b/.changeset/cuddly-shrimps-ask.md
@@ -1,0 +1,5 @@
+---
+"biome": patch
+---
+
+Fix copying of `web-tree-sitter.wasm` into `out`

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -23,7 +23,7 @@ export default defineConfig([
 			}),
 			copy({
 				targets: [
-					{ src: "node_modules/web-tree-sitter/tree-sitter.wasm", dest: "out" },
+					{ src: "node_modules/web-tree-sitter/web-tree-sitter.wasm", dest: "out" },
 					{
 						src: "node_modules/tree-sitter-gritql/tree-sitter-gritql.wasm",
 						dest: "out",


### PR DESCRIPTION
### Summary

<!-- Provide a general summary of your changes -->

This PR fixes copying of the `web-tree-sitter.wasm` file from `web-tree-sitter` package into `out` directory by `rollup` and eliminates such error in VSCode:

```
2026-03-13 20:11:42.364 [error] RuntimeError: Aborted(Error: ENOENT: no such file or directory, open 'c:\Users\User\.vscode\extensions\biomejs.biome-3.4.1\out\web-tree-sitter.wasm'). Build with -sASSERTIONS for more info.
	at abort (c:\Users\VS\.vscode\extensions\biomejs.biome-3.4.1\out\main.js:25044:13)
	at instantiateArrayBuffer (c:\Users\VS\.vscode\extensions\biomejs.biome-3.4.1\out\main.js:25085:7)
	at async createWasm (c:\Users\VS\.vscode\extensions\biomejs.biome-3.4.1\out\main.js:25143:18)
	at async Module (c:\Users\VS\.vscode\extensions\biomejs.biome-3.4.1\out\main.js:26461:17)
	at async initializeBinding (c:\Users\VS\.vscode\extensions\biomejs.biome-3.4.1\out\main.js:26479:22)
	at async Parser.init (c:\Users\VS\.vscode\extensions\biomejs.biome-3.4.1\out\main.js:26512:15)
	at async initializeTreeSitter (c:\Users\VS\.vscode\extensions\biomejs.biome-3.4.1\out\main.js:27443:5)
	at async Object.init (c:\Users\VS\.vscode\extensions\biomejs.biome-3.4.1\out\main.js:27510:3)
```

<!-- ### Description -->

<!-- Describe your changes in detail -->

<!-- ### Related Issue -->

<!-- If this PR is related to an issue, please link it here -->

<!-- This PR closes #<issue_number> -->

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [X] I have tested my changes on the following platforms:
  - [X] Windows
  - [ ] Linux
  - [ ] macOS