### PR TITLE
feat: warn about nested workspace roots

### DIFF
--- a/.changeset/swift-bears-clean.md
+++ b/.changeset/swift-bears-clean.md
@@ -1,0 +1,5 @@
+---
+"biome": minor
+---
+
+Warn when overlapping workspace roots cause multiple Biome sessions to apply to the same files.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,6 +58,20 @@
 			"sourceMapRenames": true
 		},
 		{
+			"name": "🧩 Debug Extension (overlapping workspace roots)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentKind=node",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}/test/fixtures/overlapping-roots-workspace/test.code-workspace"
+			],
+			"outFiles": ["${workspaceFolder}/out/**/*.js"],
+			"preLaunchTask": "npm: dev",
+			"sourceMapRenames": true
+		},
+		{
 			"name": "🧩 Debug Extension (requires config file but missing)",
 			"type": "extensionHost",
 			"request": "launch",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, relative, resolve } from "node:path";
 import {
 	ConfigurationTarget,
 	commands,
@@ -17,6 +18,17 @@ import Session from "./session";
 import { StatusBar } from "./status-bar";
 import type { ExecutionMode } from "./types";
 import { config, debounce } from "./utils";
+
+type FileBackedBiomeSession = {
+	name: string;
+	root: string;
+	normalizedRoot: string;
+};
+
+type OverlappingBiomeSessionPair = {
+	first: FileBackedBiomeSession;
+	second: FileBackedBiomeSession;
+};
 
 export default class Extension {
 	/**
@@ -182,6 +194,7 @@ export default class Extension {
 
 		// Finally, start the instances
 		await this.startInstances();
+		this.warnAboutOverlappingSessions();
 
 		this.logger.info(`✨ See the dedicated logging channels for more details.`);
 	}
@@ -201,6 +214,34 @@ export default class Extension {
 		}
 
 		this.logger.info("⏹️ Biome extension stopped.");
+	}
+
+	private warnAboutOverlappingSessions(): void {
+		const overlaps = this.getOverlappingSessionPairs();
+
+		if (overlaps.length === 0) {
+			return;
+		}
+
+		const openLogsAction = "Open Biome logs to see which";
+		const message =
+			"Biome started multiple sessions for some of the same files. This " +
+			"usually happens when workspace folders overlap. Make sure each " +
+			"workspace root is separate and not nested inside another one.";
+
+		this.logger.warn(message);
+
+		for (const { first, second } of overlaps) {
+			this.logger.warn(
+				`Overlapping workspace roots: "${first.name}" (${first.root}) and "${second.name}" (${second.root})`,
+			);
+		}
+
+		void window.showWarningMessage(message, openLogsAction).then((action) => {
+			if (action === openLogsAction) {
+				this.logger.show();
+			}
+		});
 	}
 
 	/**
@@ -366,6 +407,73 @@ export default class Extension {
 		}
 
 		this.logger.info(`🚀 Started ${this.biomes.size} Biome instance(s).`);
+	}
+
+	private getOverlappingSessionPairs(): OverlappingBiomeSessionPair[] {
+		const sessions = this.getFileBackedSessions();
+		const overlaps: OverlappingBiomeSessionPair[] = [];
+
+		for (let index = 0; index < sessions.length; index++) {
+			const first = sessions[index];
+
+			for (
+				let nextIndex = index + 1;
+				nextIndex < sessions.length;
+				nextIndex++
+			) {
+				const second = sessions[nextIndex];
+
+				if (!this.rootsOverlap(first.normalizedRoot, second.normalizedRoot)) {
+					continue;
+				}
+
+				overlaps.push({ first, second });
+			}
+		}
+
+		return overlaps;
+	}
+
+	private getFileBackedSessions(): FileBackedBiomeSession[] {
+		return Array.from(this.biomes.values()).flatMap((biome) => {
+			const selectorRoot = biome.session?.selectorRoot;
+
+			if (!selectorRoot) {
+				return [];
+			}
+
+			return [
+				{
+					name: biome.name,
+					root: selectorRoot.fsPath,
+					normalizedRoot: this.normalizeRootPath(selectorRoot),
+				},
+			];
+		});
+	}
+
+	private normalizeRootPath(root: Uri): string {
+		const normalizedRoot = resolve(root.fsPath);
+
+		return process.platform === "win32"
+			? normalizedRoot.toLowerCase()
+			: normalizedRoot;
+	}
+
+	private rootsOverlap(firstRoot: string, secondRoot: string): boolean {
+		return (
+			this.isSameOrNestedRoot(firstRoot, secondRoot) ||
+			this.isSameOrNestedRoot(secondRoot, firstRoot)
+		);
+	}
+
+	private isSameOrNestedRoot(root: string, candidate: string): boolean {
+		const difference = relative(root, candidate);
+
+		return (
+			difference === "" ||
+			(!difference.startsWith("..") && !isAbsolute(difference))
+		);
 	}
 
 	/**

--- a/src/session.ts
+++ b/src/session.ts
@@ -23,6 +23,10 @@ export default class Session {
 	 */
 	private client: LanguageClient | undefined;
 
+	public get selectorRoot(): Uri | undefined {
+		return this.folder?.uri ?? this.singleFileFolder;
+	}
+
 	public get biomeVersion(): string | undefined {
 		return this.client?.initializeResult?.serverInfo?.version;
 	}
@@ -213,23 +217,13 @@ export default class Session {
 	 * Creates the document selector for the language client.
 	 */
 	private createDocumentSelector(): DocumentFilter[] {
-		const folder = this.folder;
-		const singleFileFolder = this.singleFileFolder;
+		const selectorRoot = this.selectorRoot;
 
-		if (folder !== undefined) {
+		if (selectorRoot !== undefined) {
 			return supportedLanguages.map((language) => ({
 				language,
 				scheme: "file",
-				pattern: Uri.joinPath(folder.uri, "**", "*").fsPath.replaceAll(
-					"\\",
-					"/",
-				),
-			}));
-		} else if (singleFileFolder !== undefined) {
-			return supportedLanguages.map((language) => ({
-				language,
-				scheme: "file",
-				pattern: Uri.joinPath(singleFileFolder, "**", "*").fsPath.replaceAll(
+				pattern: Uri.joinPath(selectorRoot, "**", "*").fsPath.replaceAll(
 					"\\",
 					"/",
 				),

--- a/test/fixtures/overlapping-roots-workspace/outer/biome.json
+++ b/test/fixtures/overlapping-roots-workspace/outer/biome.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+	"formatter": {
+		"indentStyle": "space",
+		"indentWidth": 2
+	}
+}

--- a/test/fixtures/overlapping-roots-workspace/outer/index.js
+++ b/test/fixtures/overlapping-roots-workspace/outer/index.js
@@ -1,0 +1,5 @@
+function outerWorkspace() {
+	console.log("outer");
+}
+
+outerWorkspace();

--- a/test/fixtures/overlapping-roots-workspace/outer/nested/biome.json
+++ b/test/fixtures/overlapping-roots-workspace/outer/nested/biome.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+	"formatter": {
+		"indentStyle": "space",
+		"indentWidth": 4
+	}
+}

--- a/test/fixtures/overlapping-roots-workspace/outer/nested/index.js
+++ b/test/fixtures/overlapping-roots-workspace/outer/nested/index.js
@@ -1,0 +1,5 @@
+function nestedWorkspace() {
+	console.log("nested");
+}
+
+nestedWorkspace();

--- a/test/fixtures/overlapping-roots-workspace/test.code-workspace
+++ b/test/fixtures/overlapping-roots-workspace/test.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"name": "Workspace root",
+			"path": "outer"
+		},
+		{
+			"name": "Nested workspace root",
+			"path": "outer/nested"
+		}
+	]
+}


### PR DESCRIPTION
> [!NOTE]
> AI was used to author this PR

### Summary

This PR warns users when their workspace configurations results in the creation of multiple Biome LSP sessions that cover some of the same files.

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [x] Windows
  - [x] Linux
  - [x] macOS