### PR TITLE
feat: add SVG file support

### DIFF
--- a/.changeset/feat-svg-support.md
+++ b/.changeset/feat-svg-support.md
@@ -1,0 +1,5 @@
+---
+"biome": minor
+---
+
+Added support for `.svg` files. The extension now registers SVG as a supported language and activates Biome's LSP for `.svg` files, enabling formatting and linting.

--- a/package.json
+++ b/package.json
@@ -173,6 +173,12 @@
 				"extensions": [
 					".grit"
 				]
+			},
+			{
+				"id": "svg",
+				"extensions": [
+					".svg"
+				]
 			}
 		],
 		"grammars": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const supportedLanguages: string[] = [
 	"json",
 	"jsonc",
 	"snippets",
+	"svg",
 	"svelte",
 	"tailwindcss",
 	"typescript",


### PR DESCRIPTION
> This PR was written with AI assistance (Claude Code).

### Summary

Add support for `.svg` files in the VS Code extension.

### Description

This PR registers SVG as a supported language in the extension and adds `"svg"` to the `supportedLanguages` list so that the Biome LSP server activates for `.svg` files. This enables formatting and linting of SVG files directly in VS Code.

Changes:
- Added `{ "id": "svg", "extensions": [".svg"] }` to `contributes.languages` in `package.json`.
- Added `"svg"` to the `supportedLanguages` array in `src/constants.ts`.

### Related Issue

Related to biomejs/biome#9604 and biomejs/biome#9608.

### Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS