### PR TITLE
feat: resolve `biome.cmd` from PATH on windows

### DIFF
--- a/.changeset/lucky-lands-unite.md
+++ b/.changeset/lucky-lands-unite.md
@@ -1,0 +1,5 @@
+---
+"biome": minor
+---
+
+Resolve biome.cmd from PATH on Windows

--- a/src/biome.ts
+++ b/src/biome.ts
@@ -7,7 +7,7 @@ import {
 	type WorkspaceFolder,
 	workspace,
 } from "vscode";
-import { platformSpecificBinaryName } from "./constants";
+import { platformSpecificDefaultBinaryName } from "./constants";
 import type Extension from "./extension";
 import Locator from "./locator";
 import Logger from "./logger";
@@ -348,7 +348,7 @@ export default class Biome {
 
 			const destination = Uri.joinPath(
 				tempDirectory,
-				platformSpecificBinaryName,
+				platformSpecificDefaultBinaryName,
 			);
 
 			this.logger.debug(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,6 +64,24 @@ export const platformIdentifier = (() => {
 })();
 
 /**
+ * Platform-specific binary names
+ *
+ * This constant contains the possible names of the Biome binary for the current
+ * platform. On Windows, both "biome.exe" and "biome.cmd" are possible names for
+ * the binary, depending on how it was installed.
+ *
+ * @example "biome" (on Linux, macOS, and other Unix-like systems)
+ * @example ["biome.exe", "biome.cmd"] (on Windows)
+ */
+export const platformSpecificBinaryNames = (() => {
+	if (process.platform === "win32") {
+		return ["biome.exe", "biome.cmd"];
+	}
+
+	return ["biome"];
+})();
+
+/**
  * Platform-specific binary name
  *
  * This constant contains the name of the Biome binary for the current
@@ -72,8 +90,8 @@ export const platformIdentifier = (() => {
  * @example "biome" (on Linux, macOS, and other Unix-like systems)
  * @example "biome.exe" (on Windows)
  */
-export const platformSpecificBinaryName = (() => {
-	return `biome${process.platform === "win32" ? ".exe" : ""}`;
+export const platformSpecificDefaultBinaryName = (() => {
+	return platformSpecificBinaryNames[0];
 })();
 
 /**

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -13,7 +13,8 @@ import { Utils } from "vscode-uri";
 import type Biome from "./biome";
 import {
 	platformIdentifier,
-	platformSpecificBinaryName,
+	platformSpecificBinaryNames,
+	platformSpecificDefaultBinaryName,
 	platformSpecificNodePackageName,
 } from "./constants";
 import {
@@ -324,7 +325,7 @@ export default class Locator {
 			// Resolve the path to the biome binary.
 			const biome = Uri.joinPath(
 				pathToBiomeCliPackage,
-				platformSpecificBinaryName,
+				platformSpecificDefaultBinaryName,
 			);
 
 			if (await fileExists(biome)) {
@@ -396,7 +397,7 @@ export default class Locator {
 
 				const biome = Uri.file(
 					yarnPnpApi.resolveRequest(
-						`${platformSpecificNodePackageName}/${platformSpecificBinaryName}`,
+						`${platformSpecificNodePackageName}/${platformSpecificDefaultBinaryName}`,
 						rootBiomePackage,
 					) as string,
 				);
@@ -430,12 +431,14 @@ export default class Locator {
 		}
 
 		for (const dir of path.split(delimiter)) {
-			const biome = Uri.joinPath(Uri.file(dir), platformSpecificBinaryName);
-			if (await fileExists(biome)) {
-				this.biome.logger.debug(
-					`🔍 Found Biome binary at "${biome.fsPath}" in PATH`,
-				);
-				return biome;
+			for (const binaryName of platformSpecificBinaryNames) {
+				const biome = Uri.joinPath(Uri.file(dir), binaryName);
+				if (await fileExists(biome)) {
+					this.biome.logger.debug(
+						`🔍 Found Biome binary at "${biome.fsPath}" in PATH`,
+					);
+					return biome;
+				}
 			}
 		}
 


### PR DESCRIPTION
Co-Authored-By: @AMDphreak

### Summary

This PR allows resolving `biome.cmd` in the PATH on Windows.


### Related Issue

<!-- If this PR is related to an issue, please link it here -->

Fixes #1012

Supersedes #947

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [x] Windows
  - [ ] Linux
  - [ ] macOS