### PR TITLE
feat: resolve variables in custom path settings

### DIFF
--- a/.changeset/five-apricots-resolve.md
+++ b/.changeset/five-apricots-resolve.md
@@ -1,0 +1,6 @@
+---
+"biome": patch
+---
+
+Resolve VS Code variables in custom Biome path settings such as `biome.lsp.bin`
+and `biome.configurationPath`.

--- a/.changeset/five-apricots-resolve.md
+++ b/.changeset/five-apricots-resolve.md
@@ -1,5 +1,5 @@
 ---
-"biome": patch
+"biome": minor
 ---
 
 Resolve VS Code variables in custom Biome path settings such as `biome.lsp.bin`

--- a/src/session.ts
+++ b/src/session.ts
@@ -223,6 +223,41 @@ export default class Session {
 							}
 
 							if (
+								item.section === "biome.configurationPath" &&
+								typeof value === "string"
+							) {
+								return (
+									normalizeBiomeSettings(
+										{ configurationPath: value },
+										resource,
+									) as { configurationPath?: string }
+								).configurationPath;
+							}
+
+							if (
+								(item.section === "biome.lsp.bin" ||
+									item.section === "biome.lspBin") &&
+								(typeof value === "string" ||
+									(typeof value === "object" &&
+										value !== null &&
+										!Array.isArray(value)))
+							) {
+								if (item.section === "biome.lspBin") {
+									return (
+										normalizeBiomeSettings({ lspBin: value }, resource) as {
+											lspBin?: unknown;
+										}
+									).lspBin;
+								}
+
+								return (
+									normalizeBiomeSettings({ lsp: { bin: value } }, resource) as {
+										lsp?: { bin?: unknown };
+									}
+								).lsp?.bin;
+							}
+
+							if (
 								(item.section === undefined || item.section === null) &&
 								typeof value === "object" &&
 								value !== null &&

--- a/src/session.ts
+++ b/src/session.ts
@@ -10,7 +10,12 @@ import {
 import { displayName } from "../package.json";
 import type Biome from "./biome";
 import { supportedLanguages } from "./constants";
-import { config, type SafeSpawnSyncOptions, safeSpawnSync } from "./utils";
+import {
+	config,
+	normalizeBiomeSettings,
+	type SafeSpawnSyncOptions,
+	safeSpawnSync,
+} from "./utils";
 
 export default class Session {
 	private static watcherSupportCache = new Map<
@@ -198,6 +203,46 @@ export default class Session {
 			traceOutputChannel: outputChannel,
 			documentSelector: this.createDocumentSelector(),
 			workspaceFolder: this.folder,
+			middleware: {
+				workspace: {
+					configuration: async (params, token, next) => {
+						const settings = await next(params, token);
+
+						if (!Array.isArray(settings)) {
+							return settings;
+						}
+
+						return params.items.map((item, index) => {
+							const resource = item.scopeUri
+								? Uri.parse(item.scopeUri)
+								: undefined;
+							const value = settings[index];
+
+							if (item.section === "biome") {
+								return normalizeBiomeSettings(value, resource);
+							}
+
+							if (
+								(item.section === undefined || item.section === null) &&
+								typeof value === "object" &&
+								value !== null &&
+								!Array.isArray(value) &&
+								"biome" in value
+							) {
+								return {
+									...(value as Record<string, unknown>),
+									biome: normalizeBiomeSettings(
+										(value as Record<string, unknown>).biome,
+										resource,
+									),
+								};
+							}
+
+							return value;
+						});
+					},
+				},
+			},
 			initializationOptions: {
 				...(this.singleFileFolder && {
 					rootUri: this.singleFileFolder,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,6 +64,113 @@ export const config: {
 };
 
 /**
+ * Resolves common VS Code variables in user-provided settings.
+ *
+ * This mirrors the behavior used by other language tool extensions for path-like
+ * settings such as `${workspaceFolder}`, `${userHome}`, and `${env:NAME}`.
+ */
+export const resolveVariables = (
+	value: string,
+	workspaceFolder?: WorkspaceFolder,
+): string => {
+	let resolved = value;
+	const substitutions = new Map<string, string>();
+	const home = process.env.HOME || process.env.USERPROFILE;
+	const userHomeVariable = String.raw`\${userHome}`;
+	const workspaceFolderVariable = String.raw`\${workspaceFolder}`;
+	const cwdVariable = String.raw`\${cwd}`;
+
+	if (home) {
+		substitutions.set(userHomeVariable, home);
+	}
+
+	if (workspaceFolder) {
+		substitutions.set(workspaceFolderVariable, workspaceFolder.uri.fsPath);
+	}
+
+	substitutions.set(cwdVariable, process.cwd());
+
+	for (const folder of workspace.workspaceFolders ?? []) {
+		substitutions.set(`\${workspaceFolder:${folder.name}}`, folder.uri.fsPath);
+	}
+
+	for (const [key, envValue] of Object.entries(process.env)) {
+		if (envValue !== undefined) {
+			substitutions.set(`\${env:${key}}`, envValue);
+		}
+	}
+
+	for (const [key, substitution] of substitutions) {
+		resolved = resolved.replaceAll(key, substitution);
+	}
+
+	return resolved;
+};
+
+const resolvePathSetting = (
+	value: string,
+	workspaceFolder?: WorkspaceFolder,
+): string => resolveVariables(value, workspaceFolder);
+
+const isStringRecord = (value: unknown): value is Record<string, string> =>
+	typeof value === "object" &&
+	value !== null &&
+	!Array.isArray(value) &&
+	Object.values(value).every((entry) => typeof entry === "string");
+
+export const normalizeBiomeSettings = (
+	settings: unknown,
+	resource?: Uri,
+): unknown => {
+	if (
+		typeof settings !== "object" ||
+		settings === null ||
+		Array.isArray(settings)
+	) {
+		return settings;
+	}
+
+	const workspaceFolder = resource
+		? workspace.getWorkspaceFolder(resource)
+		: undefined;
+	const result = { ...(settings as Record<string, unknown>) };
+
+	if (typeof result.configurationPath === "string") {
+		result.configurationPath = resolvePathSetting(
+			result.configurationPath,
+			workspaceFolder,
+		);
+	}
+
+	if (typeof result.lspBin === "string") {
+		result.lspBin = resolvePathSetting(result.lspBin, workspaceFolder);
+	}
+
+	if (
+		typeof result.lsp === "object" &&
+		result.lsp !== null &&
+		!Array.isArray(result.lsp)
+	) {
+		const lspSettings = { ...(result.lsp as Record<string, unknown>) };
+
+		if (typeof lspSettings.bin === "string") {
+			lspSettings.bin = resolvePathSetting(lspSettings.bin, workspaceFolder);
+		} else if (isStringRecord(lspSettings.bin)) {
+			lspSettings.bin = Object.fromEntries(
+				Object.entries(lspSettings.bin).map(([key, entry]) => [
+					key,
+					resolvePathSetting(entry, workspaceFolder),
+				]),
+			);
+		}
+
+		result.lsp = lspSettings;
+	}
+
+	return result;
+};
+
+/**
  * Retrieves the `biome.lsp.bin` setting
  *
  * This function retrieves the `biome.lsp.bin` setting from the given scope. It
@@ -79,13 +186,17 @@ export const getLspBin = (
 		}) || config<string>("lspBin", { scope: workspaceFolder }); // deprecated setting for fallback.
 
 	const resolvePath = (lspBin: string, workspaceFolder?: WorkspaceFolder) => {
+		const resolvedPath = resolvePathSetting(lspBin, workspaceFolder);
+
 		// If the specified path is relative, resolve it against the root of
 		// the workspace folder (if any).
-		if (workspaceFolder && !isAbsolute(lspBin)) {
-			return Uri.file(Utils.resolvePath(workspaceFolder.uri, lspBin).fsPath);
+		if (workspaceFolder && !isAbsolute(resolvedPath)) {
+			return Uri.file(
+				Utils.resolvePath(workspaceFolder.uri, resolvedPath).fsPath,
+			);
 		}
 
-		return Uri.file(lspBin);
+		return Uri.file(resolvedPath);
 	};
 
 	if (typeof lspBin === "string") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,9 +76,9 @@ export const resolveVariables = (
 	let resolved = value;
 	const substitutions = new Map<string, string>();
 	const home = process.env.HOME || process.env.USERPROFILE;
-	const userHomeVariable = String.raw`\${userHome}`;
-	const workspaceFolderVariable = String.raw`\${workspaceFolder}`;
-	const cwdVariable = String.raw`\${cwd}`;
+	const userHomeVariable = "$" + "{userHome}";
+	const workspaceFolderVariable = "$" + "{workspaceFolder}";
+	const cwdVariable = "$" + "{cwd}";
 
 	if (home) {
 		substitutions.set(userHomeVariable, home);


### PR DESCRIPTION
## Summary

Fixes #721.

This updates the extension to resolve common VS Code variables in path-like Biome settings before they are used locally or returned to the language server.

### What changed

- `biome.lsp.bin` and deprecated `biome.lspBin` now expand variables such as `${workspaceFolder}`, `${workspaceFolder:name}`, `${userHome}`, `${cwd}`, and `${env:NAME}` before path resolution.
- `biome.configurationPath` now goes through the same expansion when the language server requests `biome` settings via `workspace/configuration`.
- The same configuration middleware also normalizes direct `workspace/configuration` requests for `biome.configurationPath`, `biome.lsp.bin`, and `biome.lspBin`, so local path resolution and server-side settings stay aligned.
- Added a changeset because this is a user-facing extension behavior fix.

### Why this fixes the issue

Before this change, the extension treated configured paths as literal strings. That meant settings like:

- `"biome.lsp.bin": "${userHome}/.../biome"`
- `"biome.configurationPath": "${workspaceFolder}/biome.json"`

were passed through without interpolation, so the binary lookup and config lookup failed even though the expanded paths were valid.

## Verification

### Repo checks

- `pnpm exec biome check src/session.ts src/utils.ts .changeset/five-apricots-resolve.md`
- `pnpm run typecheck`
- `pnpm run build`
- `npx -y node@24.14.1 ./node_modules/@vscode/vsce/vsce package --out biome.vsix`

Note: `pnpm run package` failed under local Node 25 because of a `vsce` dependency/runtime mismatch, but packaging succeeded under the repo's pinned Node `24.14.1` from `.node-version`.

### Manual extension-host validation

Launched a clean VS Code extension-development window with isolated `--user-data-dir` and a throwaway workspace configured with:

- `"biome.lsp.bin": "${workspaceFolder}/node_modules/.bin/biome"`
- `"biome.configurationPath": "${workspaceFolder}/biome.json"`

Observed in the extension logs that:

- `biome.lsp.bin` was expanded and successfully unshimmed from the workspace-relative path to the real bundled Biome binary.
- The `workspace/configuration` response contained `"configurationPath": "/tmp/biome-vscode-test-ws/biome.json"` as an absolute path, not the raw `${workspaceFolder}` string.

## AI assistance

I used Codex (GPT-5.4, high reasoning) to help with implementation and drafting, then reviewed the code, fixed issues found during an adversarial follow-up review, and ran the verification above.