### PR TITLE
feat: support formatting unsaved and untitled files (#818)

### DIFF
--- a/.changeset/support-unsaved-files.md
+++ b/.changeset/support-unsaved-files.md
@@ -1,0 +1,5 @@
+---
+"biome": patch
+---
+
+Fixed an issue where the extension failed to format newly created unsaved/untitled documents when a workspace folder was open.

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
 		"url": "https://github.com/sponsors/biomejs"
 	},
 	"scripts": {
-		"prebuild": "pnpm run typecheck",
+		"prebuild": "npm run typecheck",
 		"build": "rollup --config rollup.config.ts --configPlugin esbuild",
 		"dev": "rollup --watch --config rollup.config.ts --configPlugin esbuild",
-		"prepackage": "pnpm run build",
+		"prepackage": "npm run build",
 		"package": "vsce package --out biome.vsix",
 		"typecheck": "tsc --noEmit"
 	},

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
 		"url": "https://github.com/sponsors/biomejs"
 	},
 	"scripts": {
-		"prebuild": "npm run typecheck",
+		"prebuild": "pnpm run typecheck",
 		"build": "rollup --config rollup.config.ts --configPlugin esbuild",
 		"dev": "rollup --watch --config rollup.config.ts --configPlugin esbuild",
-		"prepackage": "npm run build",
+		"prepackage": "pnpm run build",
 		"package": "vsce package --out biome.vsix",
 		"typecheck": "tsc --noEmit"
 	},

--- a/src/session.ts
+++ b/src/session.ts
@@ -220,14 +220,24 @@ export default class Session {
 		const selectorRoot = this.selectorRoot;
 
 		if (selectorRoot !== undefined) {
-			return supportedLanguages.map((language) => ({
-				language,
-				scheme: "file",
-				pattern: Uri.joinPath(selectorRoot, "**", "*").fsPath.replaceAll(
-					"\\",
-					"/",
-				),
-			}));
+			return supportedLanguages.flatMap((language) => [
+				{
+					language,
+					scheme: "file",
+					pattern: Uri.joinPath(selectorRoot, "**", "*").fsPath.replaceAll(
+						"\\",
+						"/",
+					),
+				},
+				{
+					language,
+					scheme: "untitled",
+				},
+				{
+					language,
+					scheme: "vscode-userdata",
+				},
+			]);
 		}
 
 		return supportedLanguages.flatMap((language) => {


### PR DESCRIPTION
### Summary

Support formatting unsaved and untitled files.

### Description

This PR registers the document formatting provider for the `untitled` and `vscode-userdata` document schemes even when a workspace is loaded, ensuring that unsaved documents can be formatted properly.

### Related Issue

This PR closes #818

### Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS
