### PR TITLE
feat: lazily initialize single-file session when editor focuses (#934)

### DIFF
--- a/.changeset/lazy-init-single-file.md
+++ b/.changeset/lazy-init-single-file.md
@@ -1,0 +1,5 @@
+---
+"biome": patch
+---
+
+Fixed an issue where the extension failed to initialize the single-file session when VS Code was launched into an empty/unopened window.

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
 		"url": "https://github.com/sponsors/biomejs"
 	},
 	"scripts": {
-		"prebuild": "pnpm run typecheck",
+		"prebuild": "npm run typecheck",
 		"build": "rollup --config rollup.config.ts --configPlugin esbuild",
 		"dev": "rollup --watch --config rollup.config.ts --configPlugin esbuild",
-		"prepackage": "pnpm run build",
+		"prepackage": "npm run build",
 		"package": "vsce package --out biome.vsix",
 		"typecheck": "tsc --noEmit"
 	},

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
 		"url": "https://github.com/sponsors/biomejs"
 	},
 	"scripts": {
-		"prebuild": "npm run typecheck",
+		"prebuild": "pnpm run typecheck",
 		"build": "rollup --config rollup.config.ts --configPlugin esbuild",
 		"dev": "rollup --watch --config rollup.config.ts --configPlugin esbuild",
-		"prepackage": "npm run build",
+		"prepackage": "pnpm run build",
 		"package": "vsce package --out biome.vsix",
 		"typecheck": "tsc --noEmit"
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -189,8 +189,6 @@ export default class Extension {
 
 		// Register a callback to update the status bar when the active text editor changes
 		window.onDidChangeActiveTextEditor(async () => {
-			this.statusBar.update();
-
 			if (this.mode === "single-file" && !this.biomes.has("single")) {
 				await this.createSingleFileInstance();
 				const singleInstance = this.biomes.get("single");
@@ -199,6 +197,8 @@ export default class Extension {
 					this.logger.info("🚀 Lazily initialized and started single-file Biome session.");
 				}
 			}
+
+			this.statusBar.update();
 		});
 
 		// Finally, start the instances

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,8 +188,17 @@ export default class Extension {
 		}
 
 		// Register a callback to update the status bar when the active text editor changes
-		window.onDidChangeActiveTextEditor(() => {
+		window.onDidChangeActiveTextEditor(async () => {
 			this.statusBar.update();
+
+			if (this.mode === "single-file" && !this.biomes.has("single")) {
+				await this.createSingleFileInstance();
+				const singleInstance = this.biomes.get("single");
+				if (singleInstance) {
+					await singleInstance.start();
+					this.logger.info("🚀 Lazily initialized and started single-file Biome session.");
+				}
+			}
 		});
 
 		// Finally, start the instances

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -194,7 +194,9 @@ export default class Extension {
 				const singleInstance = this.biomes.get("single");
 				if (singleInstance) {
 					await singleInstance.start();
-					this.logger.info("🚀 Lazily initialized and started single-file Biome session.");
+					this.logger.info(
+						"🚀 Lazily initialized and started single-file Biome session.",
+					);
 				}
 			}
 


### PR DESCRIPTION
### Summary

Lazy single-file session initialization.

### Description

This PR introduces lazy single-file session initialization inside the window active text editor change listener. If the extension starts up with an empty/unopened window in single-file mode, the server session is deferred and dynamically initialized once a supported editor tab becomes focused.

### Related Issue

This PR closes #934

### Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] Windows
  - [ ] Linux
  - [x] macOS