### PR TITLE
chore: log Biome binary temporary-copy errors

### DIFF
--- a/.changeset/mighty-trams-bow.md
+++ b/.changeset/mighty-trams-bow.md
@@ -1,0 +1,5 @@
+---
+"biome": patch
+---
+
+Log the underlying error when copying the Biome binary to a temporary location fails, so Windows temporary-copy failures are easier to diagnose.

--- a/src/biome.ts
+++ b/src/biome.ts
@@ -364,7 +364,10 @@ export default class Biome {
 			chmodSync(destination.fsPath, 0o755);
 
 			return destination;
-		} catch (_error) {
+		} catch (error) {
+			this.logger.error(
+				`Failed to copy the Biome binary to a temporary location: ${error}`,
+			);
 			await this.cleanup();
 			return undefined;
 		}


### PR DESCRIPTION
### Summary

- Log the underlying error when copying the Biome binary to a temporary location fails.
- Keep the existing cleanup and failure behavior unchanged.

### Description

This is a diagnostic precursor to #1080. The current failure path hides the copy error and later reports only "Unable to find the Biome binary", which makes it difficult to confirm which underlying file-system error Windows users are hitting.

This PR intentionally does not fix the temporary-copy failure. It only makes the root error visible so affected users can provide better logs.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

Refs #1080

### Checklist

<!-- Please check the platforms you have tested this change on -->

- [ ] I have tested my changes on the following platforms:
  - [x] Windows
  - [ ] Linux
  - [x] macOS