### PR TITLE
fix: reuse locked temporary Biome binary on Windows

### DIFF
--- a/.changeset/ready-monkeys-create.md
+++ b/.changeset/ready-monkeys-create.md
@@ -1,0 +1,5 @@
+---
+"biome": patch
+---
+
+Fixed [#1080](https://github.com/biomejs/biome-vscode/issues/1080): reuse the locked temporary Biome binary on Windows instead of failing to start.

--- a/src/biome.ts
+++ b/src/biome.ts
@@ -13,7 +13,7 @@ import Locator from "./locator";
 import Logger from "./logger";
 import Session from "./session";
 import type { State } from "./types";
-import { config, debounce } from "./utils";
+import { config, debounce, fileExists } from "./utils";
 
 type StopOptions = {
 	waitForConfigurationChange?: boolean;
@@ -355,13 +355,36 @@ export default class Biome {
 				`Will copy the original binary at ${originalBinary.fsPath} to ${destination.fsPath}`,
 			);
 
-			copyFileSync(originalBinary.fsPath, destination.fsPath);
+			try {
+				copyFileSync(originalBinary.fsPath, destination.fsPath);
 
-			this.logger.debug(
-				`Copied the original binary to a temporary location: ${destination.fsPath}`,
-			);
+				this.logger.debug(
+					`Copied the original binary to a temporary location: ${destination.fsPath}`,
+				);
 
-			chmodSync(destination.fsPath, 0o755);
+				chmodSync(destination.fsPath, 0o755);
+			} catch (copyError) {
+				// On Windows, the destination binary may be locked (EBUSY/EPERM) by
+				// a Biome process from a previous session that is still running (for
+				// example after a window reload). Overwriting a running executable is
+				// not allowed, but a locked destination means a valid copy already
+				// exists there, and Windows still allows spawning new processes from
+				// it. So instead of failing — which surfaces to the user as "Unable
+				// to find the Biome binary" — reuse the existing copy.
+				const code = (copyError as NodeJS.ErrnoException).code;
+
+				if (
+					(code === "EBUSY" || code === "EPERM") &&
+					(await fileExists(destination))
+				) {
+					this.logger.warn(
+						`Could not refresh the temporary Biome binary (${code}: locked by a running instance). Reusing the existing copy at ${destination.fsPath}.`,
+					);
+					return destination;
+				}
+
+				throw copyError;
+			}
 
 			return destination;
 		} catch (error) {


### PR DESCRIPTION
### Summary

On Windows, the extension could intermittently fail to start with `Unable to find the Biome binary` when the temporary `biome.exe` copy was locked by an orphaned Biome process. This reuses the existing temporary copy instead of failing in that case.

### Description

Root cause and reproduction details are covered in #1080.

On Windows, `copyToTemporaryLocation` overwrites a per-workspace copy of `biome.exe` on every start. That overwrite can fail with `EBUSY`/`EPERM` when a process from a previous session is still running from, and therefore locking, that copy.

In this situation, the destination already exists and is expected to be a previously written temporary Biome binary. Windows still allows new processes to spawn from that existing executable, even though overwriting it fails. So instead of treating the lock as fatal, `copyToTemporaryLocation` now catches `EBUSY`/`EPERM` and, when a copy already exists at the destination, reuses it with a warning log rather than failing.

Any other error is rethrown, so the existing cleanup-and-bail behavior is unchanged.

### Known limitation

When the existing copy is reused, it is not refreshed. If the located Biome binary has changed since the temporary copy was created, for example after an upgrade in `node_modules`, while the old temporary copy is still locked, the extension may keep running the older copy until the locking process exits and the copy can be overwritten again.

This is a deliberate trade-off. Reusing the existing copy is preferable to failing to start, and the fallback is surfaced by a warning log. A complete fix still depends on resolving the underlying orphaned-process leak in #874 so the temporary copy is not left locked in the first place.

### Notes on reproduction

I couldn't find a 100% reliable reproduction. It rarely surfaces in the debug session, the Extension Development Host, but I was able to confirm it with a locally packaged and installed VSIX build by repeatedly reloading the window on Windows until an orphaned `biome.exe` kept the temporary copy locked. A capture is attached below.

<img width="762" height="68" alt="image" src="https://github.com/user-attachments/assets/7b31da51-5c77-43ba-a736-526efaf3c947" />


### Related Issue

This PR closes #1080

### Checklist

- [x] I have tested my changes on the following platforms:
  - [x] Windows
  - [ ] Linux
  - [x] macOS
