### PR TITLE
fix: detect biome.cmd on Windows PATH and unshim for global/single-file LSP

### DIFF
--- a/.changeset/windows-path-shims.md
+++ b/.changeset/windows-path-shims.md
@@ -1,0 +1,5 @@
+---
+"biome": patch
+---
+
+Fix global/single-file detection on Windows when Biome is installed via pnpm/npm/Volta shims (`biome.cmd` on PATH). Resolve `.cmd` through the existing unshim path so the LSP starts the real `biome.exe`.

--- a/src/biome.ts
+++ b/src/biome.ts
@@ -7,7 +7,7 @@ import {
 	type WorkspaceFolder,
 	workspace,
 } from "vscode";
-import { platformSpecificBinaryName } from "./constants";
+import { platformSpecificDefaultBinaryName } from "./constants";
 import type Extension from "./extension";
 import Locator from "./locator";
 import Logger from "./logger";
@@ -348,7 +348,7 @@ export default class Biome {
 
 			const destination = Uri.joinPath(
 				tempDirectory,
-				platformSpecificBinaryName,
+				platformSpecificDefaultBinaryName,
 			);
 
 			this.logger.debug(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,17 +65,44 @@ export const platformIdentifier = (() => {
 })();
 
 /**
- * Platform-specific binary name
+ * Platform-specific binary names
  *
- * This constant contains the name of the Biome binary for the current
- * platform.
+ * Possible Biome binary/shim names for the current platform. On Windows,
+ * package managers expose `biome.cmd` (and sometimes `biome.ps1`) on PATH
+ * rather than `biome.exe`. The real executable usually lives in a
+ * content-addressable store outside PATH.
+ *
+ * @example ["biome"] (on Linux, macOS, and other Unix-like systems)
+ * @example ["biome.exe", "biome.cmd"] (on Windows)
+ */
+export const platformSpecificBinaryNames = (() => {
+	if (process.platform === "win32") {
+		return ["biome.exe", "biome.cmd"];
+	}
+
+	return ["biome"];
+})();
+
+/**
+ * Platform-specific default binary name
+ *
+ * Preferred name when resolving a binary inside a known package directory
+ * (node_modules / Yarn PnP), where the real `biome.exe` (Windows) or
+ * `biome` (Unix) is present.
  *
  * @example "biome" (on Linux, macOS, and other Unix-like systems)
  * @example "biome.exe" (on Windows)
  */
-export const platformSpecificBinaryName = (() => {
-	return `biome${process.platform === "win32" ? ".exe" : ""}`;
+export const platformSpecificDefaultBinaryName = (() => {
+	return platformSpecificBinaryNames[0];
 })();
+
+/**
+ * @deprecated Use {@link platformSpecificDefaultBinaryName} or
+ * {@link platformSpecificBinaryNames}. Kept as an alias for call sites that
+ * intentionally want the real package binary name.
+ */
+export const platformSpecificBinaryName = platformSpecificDefaultBinaryName;
 
 /**
  * Platform-specific package name

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -102,8 +102,12 @@ export default class Locator {
 
 			// Set the current working directory to the project root, if it exists. This runs the `biome` binary from the
 			// project root in case the user's local development environment depends on this, such as when using `asdf`.
-			if (this.biome.workspaceFolder?.uri)
-				spawnSyncOptions.cwd = this.biome.workspaceFolder.uri.fsPath;
+			const folder =
+				this.biome.workspaceFolder?.uri ?? this.biome.singleFileFolder;
+
+			if (folder) {
+				spawnSyncOptions.cwd = folder.fsPath;
+			}
 
 			// Check the version of Biome
 			const version = safeSpawnSync(

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -14,7 +14,8 @@ import { Utils } from "vscode-uri";
 import type Biome from "./biome";
 import {
 	platformIdentifier,
-	platformSpecificBinaryName,
+	platformSpecificBinaryNames,
+	platformSpecificDefaultBinaryName,
 	platformSpecificNodePackageName,
 } from "./constants";
 import {
@@ -189,12 +190,19 @@ export default class Locator {
 	 * 2. Check the system's PATH environment variable for a Biome binary.
 	 */
 	public async findBiomeForGlobalInstance(): Promise<Uri | undefined> {
-		return (
+		const biome =
 			(await this.findBiomeInSettings()) ??
 			(await this.findBiomeInGlobalNodeModules()) ??
-			(await this.findBiomeInPath()) ??
-			(await this.suggestInstallingBiomeGlobally())
-		);
+			(await this.findBiomeInPath());
+
+		if (!biome) {
+			return await this.suggestInstallingBiomeGlobally();
+		}
+
+		// Global/single-file sessions also need unshim: Windows package managers
+		// put biome.cmd on PATH, and the language client cannot spawn .cmd without
+		// a shell. unshim() resolves the real biome.exe via __where_am_i.
+		return await this.unshim(biome);
 	}
 
 	/**
@@ -348,7 +356,7 @@ export default class Locator {
 			// Resolve the path to the biome binary.
 			const biome = Uri.joinPath(
 				pathToBiomeCliPackage,
-				platformSpecificBinaryName,
+				platformSpecificDefaultBinaryName,
 			);
 
 			if (await fileExists(biome)) {
@@ -414,7 +422,7 @@ export default class Locator {
 
 				const biome = Uri.file(
 					yarnPnpApi.resolveRequest(
-						`${platformSpecificNodePackageName}/${platformSpecificBinaryName}`,
+						`${platformSpecificNodePackageName}/${platformSpecificDefaultBinaryName}`,
 						rootBiomePackage,
 					) as string,
 				);
@@ -448,12 +456,14 @@ export default class Locator {
 		}
 
 		for (const dir of path.split(delimiter)) {
-			const biome = Uri.joinPath(Uri.file(dir), platformSpecificBinaryName);
-			if (await fileExists(biome)) {
-				this.biome.logger.debug(
-					`🔍 Found Biome binary at "${biome.fsPath}" in PATH`,
-				);
-				return biome;
+			for (const binaryName of platformSpecificBinaryNames) {
+				const biome = Uri.joinPath(Uri.file(dir), binaryName);
+				if (await fileExists(biome)) {
+					this.biome.logger.debug(
+						`🔍 Found Biome binary at "${biome.fsPath}" in PATH`,
+					);
+					return biome;
+				}
 			}
 		}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -154,8 +154,11 @@ export const safeSpawnSync = (
 	}
 
 	// Windows .cmd/.bat shims (npm, pnpm, Volta, etc.) cannot be spawned without
-	// a shell — Node returns EINVAL. Enable shell so unshim/version probes work.
+	// a shell — Node returns EINVAL. Build one quoted command string so paths with
+	// spaces work and we avoid DEP0190 (args + shell: true).
 	if (extension === ".cmd" || extension === ".bat") {
+		command = `"${command}" ${args.join(" ")}`;
+		args = [];
 		spawnOptions.shell = true;
 	}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,19 @@ import { Utils } from "vscode-uri";
 export const fileExists = async (uri: Uri): Promise<boolean> => {
 	try {
 		const stat = await workspace.fs.stat(uri);
-		return (stat.type & FileType.File) > 0;
+		// FileType.SymbolicLink is normally OR'd with File/Directory. Treat a
+		// non-directory symlink as an existing file so WinGet Links (and similar
+		// reparse-point shims) are not skipped by PATH search.
+		if ((stat.type & FileType.File) > 0) {
+			return true;
+		}
+		if (
+			(stat.type & FileType.SymbolicLink) > 0 &&
+			(stat.type & FileType.Directory) === 0
+		) {
+			return true;
+		}
+		return false;
 	} catch (_err) {
 		return false;
 	}
@@ -131,16 +143,25 @@ export const safeSpawnSync = (
 	options?: SafeSpawnSyncOptions,
 ): string | undefined => {
 	let output: string | undefined;
+	const spawnOptions: SafeSpawnSyncOptions = { ...(options ?? {}) };
+
+	const extension = extname(command).toLowerCase();
 
 	// If the command is a powershell script, run it through powershell
-	if (extname(command) === ".ps1") {
+	if (extension === ".ps1") {
 		args = [command, ...args];
 		command = "powershell.exe";
 	}
 
+	// Windows .cmd/.bat shims (npm, pnpm, Volta, etc.) cannot be spawned without
+	// a shell — Node returns EINVAL. Enable shell so unshim/version probes work.
+	if (extension === ".cmd" || extension === ".bat") {
+		spawnOptions.shell = true;
+	}
+
 	try {
 		const result = spawnSync(command, args, {
-			...(options ?? {}),
+			...spawnOptions,
 			encoding: "utf8",
 		});
 


### PR DESCRIPTION
﻿## Summary

- **Still broken on marketplace 3.7.1 / current `main`.** A global pnpm/npm install puts `biome.cmd` on PATH. The extension only looks for `biome.exe`, fails the lookup, and shows *"Please install Biome globally..."* even though Biome is already installed and runnable.
- **#1013 never shipped.** #947 was closed as superseded by #1013. That PR has been open/approved since April and is still unmerged, so users never got the PATH shim fix.
- **#1013 is also incomplete as written.** Finding `biome.cmd` without unshim + shell spawn still fails: Node returns `EINVAL` when spawning `.cmd` without a shell (reproduced; same failure mode as #1012 with Volta). Global/single-file sessions never called `unshim()`, so the language client would still be handed a shim.

## What this PR does

1. PATH search accepts `biome.exe` **and** `biome.cmd` on Windows (same idea as #1013 / #947).
2. `findBiomeForGlobalInstance` runs `unshim()` so single-file/global LSP gets the real `biome.exe`.
3. `safeSpawnSync` sets `shell: true` for `.cmd`/`.bat` so `--version` / `__where_am_i` work.
4. `fileExists` treats non-directory symlinks as files (WinGet Links reparse points).

## Reproduction (this machine)

- `pnpm add -g @biomejs/biome` → `%LOCALAPPDATA%\pnpm\biome.CMD` on PATH, **no** `biome.exe` in that directory.
- Extension 3.7.1, single-file mode, empty/non-workspace window → toast fires; `Biome (single-file)` log stops after settings listener because `showWarningMessage` blocks `start()` before the "Unable to find" error is written.
- `spawnSync(biome.CMD, ['--version'])` → `EINVAL`; with `shell: true` → `Version: 2.3.13`.
- Bonus: `pnpm root -g` via `shell: true` also fails here when pnpm's configured bin dir is not on PATH, so global node_modules discovery does not save you.

## Related

- Completes / supersedes #1013
- Follow-up to #947 (closed as superseded by the unmerged #1013)
- Related: #1012, #926, #944

## Test plan

- [ ] Windows: global `pnpm add -g @biomejs/biome`, open a file **outside** any workspace → no "install globally" toast; `Biome (single-file)` / global channel shows ready
- [ ] Windows: WinGet `biome.exe` symlink under `WinGet\Links` still resolves
- [ ] Windows: `biome.lsp.bin` pointing at a `.cmd` shim unshims to `biome.exe` and starts LSP
- [ ] Linux/macOS: PATH / node_modules resolution unchanged
